### PR TITLE
fix error with metrics from deleted LoadBalancerMachines

### DIFF
--- a/controllers/yawol-controller/loadbalancerset/loadbalancerset_controller.go
+++ b/controllers/yawol-controller/loadbalancerset/loadbalancerset_controller.go
@@ -124,13 +124,15 @@ func (r *LoadBalancerSetReconciler) deletionRoutine(
 		return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
 	}
 
-	// remove finalizer
-	kubernetes.RemoveFinalizerIfNeeded(ctx, r.Client, set, FINALIZER)
-
 	helper.RemoveLoadBalancerSetMetrics(
 		*set,
 		r.Metrics,
 	)
+
+	// remove finalizer
+	if err := kubernetes.RemoveFinalizerIfNeeded(ctx, r.Client, set, FINALIZER); err != nil {
+		return ctrl.Result{}, err
+	}
 
 	// stop reconciliation as item is being deleted
 	return ctrl.Result{}, nil


### PR DESCRIPTION
In some cases it is possible to get metrics from old LoadBalancerMachines.

Move the updates of metrics after the deletion check and delete metrics before removing finalizer. This will get NO updates of metrics while deletion of an object but makes sure no stale metrics are collected.