### PR TITLE
use self-hosted runner for ci test

### DIFF
--- a/.github/workflows/images.yaml
+++ b/.github/workflows/images.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     env:
       FORCE_COLOR: 1
     steps:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -4,7 +4,7 @@ on: [pull_request]
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     env:
       # is an empty string if it doesn't exists
       SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}


### PR DESCRIPTION
Using self-hosted runners for faster CI runs.