### PR TITLE
change keepalived settings, add envoy tcp idle timeout, add envoy tcp idle timeout metric

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,10 @@ metadata:
     yawol.stackit.cloud/logForward: "true"
     # defines loki URL for the log forwarding
     yawol.stackit.cloud/logForwardLokiURL: "http://example.com:3100/loki/api/v1/push"
+    # defines the TCP idle Timeout in seconds, default is 3600
+    yawol.stackit.cloud/tcpIdleTimeout: "300"
+    # defines the UDP idle Timeout in seconds, default is 60
+    yawol.stackit.cloud/udpIdleTimeout: "300"
 ```
 
 See [our example service](example-setup/yawol-cloud-controller/service.yaml)

--- a/api/v1beta1/loadbalancer_types.go
+++ b/api/v1beta1/loadbalancer_types.go
@@ -27,6 +27,10 @@ const (
 	ServiceTCPProxyProtocol = "yawol.stackit.cloud/tcpProxyProtocol"
 	// ServiceTCPProxyProtocolPortsFilter enables for the specified ports (comma separated list)
 	ServiceTCPProxyProtocolPortsFilter = "yawol.stackit.cloud/tcpProxyProtocolPortsFilter"
+	// ServiceTCPIdleTimeout sets the TCP idle Timeout in seconds, default is 3600
+	ServiceTCPIdleTimeout = "yawol.stackit.cloud/tcpIdleTimeout"
+	// ServiceUDPIdleTimeout sets the UDP idle Timeout in seconds, default is 60
+	ServiceUDPIdleTimeout = "yawol.stackit.cloud/udpIdleTimeout"
 	// ServiceExistingFloatingIP enables usage of existing Floating IP
 	ServiceExistingFloatingIP = "yawol.stackit.cloud/existingFloatingIP"
 	// ServiceLogForward enables log forward for LoadBalancer
@@ -104,6 +108,16 @@ type LoadBalancerOptions struct {
 	// If empty it is enabled for all ports. Only has an affect if TCPProxyProtocol is enabled.
 	// +optional
 	TCPProxyProtocolPortsFilter []int32 `json:"tcpProxyProtocolPortFilter,omitempty"`
+	// TCPIdleTimeout sets TCP idle Timeout for all TCP connections from this LoadBalancer.
+	// Value is in Seconds. With 0 you disable the idle timeout, be careful this can lead to side effects.
+	// Default is 3600s (1 hour).
+	// +optional
+	TCPIdleTimeout *int `json:"tcpIdleTimeout,omitempty"`
+	// UDPIdleTimeout sets UDP idle Timeout for all UDP connections from this LoadBalancer.
+	// Value is in Seconds. With 0 you disable the idle timeout, be careful this can lead to side effects.
+	// Default is 60s (1 minute).
+	// +optional
+	UDPIdleTimeout *int `json:"udpIdleTimeout,omitempty"`
 	// LogForward enables log forward to a loki instance
 	// +optional
 	LogForward LoadBalancerLogForward `json:"logForward,omitempty"`

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -348,6 +348,16 @@ func (in *LoadBalancerOptions) DeepCopyInto(out *LoadBalancerOptions) {
 		*out = make([]int32, len(*in))
 		copy(*out, *in)
 	}
+	if in.TCPIdleTimeout != nil {
+		in, out := &in.TCPIdleTimeout, &out.TCPIdleTimeout
+		*out = new(int)
+		**out = **in
+	}
+	if in.UDPIdleTimeout != nil {
+		in, out := &in.UDPIdleTimeout, &out.UDPIdleTimeout
+		*out = new(int)
+		**out = **in
+	}
 	out.LogForward = in.LogForward
 }
 

--- a/charts/yawol-controller/crds/yawol.stackit.cloud_loadbalancers.yaml
+++ b/charts/yawol-controller/crds/yawol.stackit.cloud_loadbalancers.yaml
@@ -182,6 +182,12 @@ spec:
                           http://example.com:3100/loki/api/v1/push).'
                         type: string
                     type: object
+                  tcpIdleTimeout:
+                    description: TCPIdleTimeout sets TCP idle Timeout for all TCP
+                      connections from this LoadBalancer. Value is in Seconds. With
+                      0 you disable the idle timeout, be careful this can lead to
+                      side effects. Default is 3600s (1 hour).
+                    type: integer
                   tcpProxyProtocol:
                     description: TCPProxyProtocol enables HAProxy TCP Proxy Protocol
                     type: boolean
@@ -193,6 +199,12 @@ spec:
                       format: int32
                       type: integer
                     type: array
+                  udpIdleTimeout:
+                    description: UDPIdleTimeout sets UDP idle Timeout for all UDP
+                      connections from this LoadBalancer. Value is in Seconds. With
+                      0 you disable the idle timeout, be careful this can lead to
+                      side effects. Default is 60s (1 minute).
+                    type: integer
                 type: object
               ports:
                 description: Ports defines the Ports for the LoadBalancer (copy from

--- a/controllers/yawol-cloud-controller/targetcontroller/service_controller.go
+++ b/controllers/yawol-cloud-controller/targetcontroller/service_controller.go
@@ -390,6 +390,24 @@ func (r *ServiceReconciler) reconcileOptions(
 		return r.ControlClient.Patch(ctx, lb, client.RawPatch(types.MergePatchType, patch))
 	}
 
+	if !reflect.DeepEqual(newOptions.TCPIdleTimeout, lb.Spec.Options.TCPIdleTimeout) {
+		data, err := json.Marshal(newOptions.TCPIdleTimeout)
+		if err != nil {
+			return err
+		}
+		patch := []byte(`{"spec":{"options":{"tcpIdleTimeout":` + string(data) + `}}}`)
+		return r.ControlClient.Patch(ctx, lb, client.RawPatch(types.MergePatchType, patch))
+	}
+
+	if !reflect.DeepEqual(newOptions.UDPIdleTimeout, lb.Spec.Options.UDPIdleTimeout) {
+		data, err := json.Marshal(newOptions.UDPIdleTimeout)
+		if err != nil {
+			return err
+		}
+		patch := []byte(`{"spec":{"options":{"udpIdleTimeout":` + string(data) + `}}}`)
+		return r.ControlClient.Patch(ctx, lb, client.RawPatch(types.MergePatchType, patch))
+	}
+
 	return nil
 }
 

--- a/docs/components.md
+++ b/docs/components.md
@@ -138,3 +138,8 @@ List of metrics:
 | keepalivedReleasedMaster         | keepalived counter released master                 |
 | keepalivedAdvertisementsSent     | keepalived counter of sent advertisements          |
 | keepalivedAdvertisementsReceived | keepalived counter of received advertisements      |
+| *-upstream_cx_active             | currently active connections per port              |
+| *-upstream_cx_total              | total connections since start per port             |
+| *-upstream_cx_rx_bytes_total     | bytes sent since start per port (lb -> client)     |
+| *-upstream_cx_tx_bytes_total     | bytes sent since start per port (client -> lb)     |
+| envoytcp-idle_timeout            | total idle tcp connections since start             |

--- a/internal/envoystatus/envoystatus_test.go
+++ b/internal/envoystatus/envoystatus_test.go
@@ -2,11 +2,13 @@ package envoystatus
 
 import (
 	"fmt"
+	"testing"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
 	"github.com/stackitcloud/yawol/api/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"testing"
 )
 
 var wanted = []v1beta1.LoadBalancerMachineMetric{

--- a/internal/envoystatus/envoystatus_test.go
+++ b/internal/envoystatus/envoystatus_test.go
@@ -1,0 +1,90 @@
+package envoystatus
+
+import (
+	"fmt"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/stackitcloud/yawol/api/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"testing"
+)
+
+var wanted = []v1beta1.LoadBalancerMachineMetric{
+	{
+		Type:  "TCP-80-upstream_cx_active",
+		Value: "1",
+		Time:  metav1.Time{},
+	},
+	{
+		Type:  "TCP-80-upstream_cx_total",
+		Value: "16",
+		Time:  metav1.Time{},
+	},
+	{
+		Type:  "TCP-80-upstream_cx_connect_fail",
+		Value: "5",
+		Time:  metav1.Time{},
+	},
+	{
+		Type:  "TCP-80-upstream_cx_rx_bytes_total",
+		Value: "11405",
+		Time:  metav1.Time{},
+	},
+	{
+		Type:  "TCP-80-upstream_cx_tx_bytes_total",
+		Value: "2984",
+		Time:  metav1.Time{},
+	},
+	{
+		Type:  "envoytcp-idle_timeout",
+		Value: "2",
+		Time:  metav1.Time{},
+	},
+}
+
+var envoyMetrics = `
+cluster.TCP-80.upstream_cx_active: 1
+cluster.TCP-80.upstream_cx_total: 16
+cluster.TCP-80.upstream_cx_connect_fail: 5
+cluster.TCP-80.upstream_cx_tx_bytes_total: 2984
+cluster.TCP-80.upstream_cx_rx_bytes_total: 11405
+tcp.envoytcp.idle_timeout: 2
+`
+
+func TestEnvoyStats4(t *testing.T) {
+	RegisterFailHandler(Fail)
+
+	RunSpecs(t, "")
+}
+
+var _ = Describe("check envoy status", func() {
+	When("Envoy stats to LoadBalancerMachine Metrics", func() {
+		It("should set the correct metrics", func() {
+			got, err := parseEnvoyMetricsToLoadBalancerMachineMetrics(envoyMetrics)
+			Expect(err).ToNot(HaveOccurred())
+			fmt.Println(got)
+			Expect(compareMetrics(got, wanted)).To(BeTrue())
+
+		})
+	})
+})
+
+func compareMetrics(got, wanted []v1beta1.LoadBalancerMachineMetric) bool {
+	for iWant := range wanted {
+		found := false
+		for iGot := range got {
+			if wanted[iWant].Type != got[iGot].Type {
+				continue
+			}
+			found = true
+			if wanted[iWant].Value != got[iGot].Value {
+				return false
+			}
+			break
+		}
+		if !found {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/helper/loadbalancermachine.go
+++ b/internal/helper/loadbalancermachine.go
@@ -253,11 +253,12 @@ vrrp_track_process envoy {
 }
 
 vrrp_instance ` + VRRPInstanceName + ` {
-	state MASTER
+	state BACKUP
 	interface eth0
+	nopreempt
 	virtual_router_id 100
-	priority 100
-	advert_int 1
+	priority 50
+	advert_int 4
 
 	authentication {
 		auth_type PASS

--- a/internal/helper/service.go
+++ b/internal/helper/service.go
@@ -64,6 +64,21 @@ func GetOptions(svc *coreV1.Service) yawolv1beta1.LoadBalancerOptions {
 			options.LogForward.LokiURL = svc.Annotations[yawolv1beta1.ServiceLogForwardLokiURL]
 		}
 	}
+
+	if svc.Annotations[yawolv1beta1.ServiceTCPIdleTimeout] != "" {
+		tcpIdleTimeout, err := strconv.Atoi(svc.Annotations[yawolv1beta1.ServiceTCPIdleTimeout])
+		if err == nil {
+			options.TCPIdleTimeout = &tcpIdleTimeout
+		}
+	}
+
+	if svc.Annotations[yawolv1beta1.ServiceUDPIdleTimeout] != "" {
+		udpIdleTimeout, err := strconv.Atoi(svc.Annotations[yawolv1beta1.ServiceUDPIdleTimeout])
+		if err == nil {
+			options.UDPIdleTimeout = &udpIdleTimeout
+		}
+	}
+
 	return options
 }
 

--- a/internal/helper/yawollet.go
+++ b/internal/helper/yawollet.go
@@ -370,8 +370,8 @@ func createEnvoyUDPListener(
 	}
 
 	var idleTimeout *duration.Duration
-	if lb.Spec.Options.TCPIdleTimeout != nil {
-		idleTimeout = &duration.Duration{Seconds: int64(*lb.Spec.Options.TCPIdleTimeout)}
+	if lb.Spec.Options.UDPIdleTimeout != nil {
+		idleTimeout = &duration.Duration{Seconds: int64(*lb.Spec.Options.UDPIdleTimeout)}
 	}
 
 	listenPort, err := anypb.New(&envoyudp.UdpProxyConfig{

--- a/internal/helper/yawollet.go
+++ b/internal/helper/yawollet.go
@@ -285,7 +285,7 @@ func createEnvoyListener(
 		if string(port.Protocol) == protocolTCP {
 			listeners[i] = createEnvoyTCPListener(r, lb, listenAddress, port)
 		} else if string(port.Protocol) == protocolUDP {
-			listeners[i] = createEnvoyUDPListener(listenAddress, port)
+			listeners[i] = createEnvoyUDPListener(lb, listenAddress, port)
 		}
 	}
 
@@ -298,10 +298,16 @@ func createEnvoyTCPListener(
 	listenAddress string,
 	port corev1.ServicePort,
 ) *envoylistener.Listener {
+	var idleTimeout *duration.Duration
+
+	if lb.Spec.Options.TCPIdleTimeout != nil {
+		idleTimeout = &duration.Duration{Seconds: int64(*lb.Spec.Options.TCPIdleTimeout)}
+	}
+
 	listenPort, err := anypb.New(&envoytcp.TcpProxy{
 		StatPrefix:       "envoytcp",
 		ClusterSpecifier: &envoytcp.TcpProxy_Cluster{Cluster: fmt.Sprintf("%v-%v", port.Protocol, port.Port)},
-		IdleTimeout:      &duration.Duration{Seconds: 300}, // default is one hour, prevent idle connection in cases of openstack server migration
+		IdleTimeout:      idleTimeout,
 	})
 
 	if err != nil {
@@ -352,6 +358,7 @@ func createEnvoyTCPListener(
 }
 
 func createEnvoyUDPListener(
+	lb *yawolv1beta1.LoadBalancer,
 	listenAddress string,
 	port corev1.ServicePort,
 ) *envoylistener.Listener {
@@ -362,8 +369,14 @@ func createEnvoyUDPListener(
 		panic(err)
 	}
 
+	var idleTimeout *duration.Duration
+	if lb.Spec.Options.TCPIdleTimeout != nil {
+		idleTimeout = &duration.Duration{Seconds: int64(*lb.Spec.Options.TCPIdleTimeout)}
+	}
+
 	listenPort, err := anypb.New(&envoyudp.UdpProxyConfig{
-		StatPrefix: "envoyudp",
+		StatPrefix:  "envoyudp",
+		IdleTimeout: idleTimeout,
 		RouteSpecifier: &envoyudp.UdpProxyConfig_Matcher{
 			Matcher: &xdsmatcher.Matcher{
 				OnNoMatch: &xdsmatcher.Matcher_OnMatch{

--- a/internal/helper/yawollet.go
+++ b/internal/helper/yawollet.go
@@ -301,6 +301,7 @@ func createEnvoyTCPListener(
 	listenPort, err := anypb.New(&envoytcp.TcpProxy{
 		StatPrefix:       "envoytcp",
 		ClusterSpecifier: &envoytcp.TcpProxy_Cluster{Cluster: fmt.Sprintf("%v-%v", port.Protocol, port.Port)},
+		IdleTimeout:      &duration.Duration{Seconds: 300}, // default is one hour, prevent idle connection in cases of openstack server migration
 	})
 
 	if err != nil {


### PR DESCRIPTION
change keepalived settings:
- advert_int to 4 (because of failed swaps while openstack migrations)
- default state to BACKUP

add envoy tcp/udp idle timeout:
- make it configurable 

add envoy tcp idle timeout metric:
- add metric to lbm for number of tcp idle timeouts 
- add tests for metric generation