### PR TITLE
change udpIdleTimeout and tcpIdleTimeout from int to metav1.Duration

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,10 +212,12 @@ metadata:
     yawol.stackit.cloud/logForward: "true"
     # defines loki URL for the log forwarding
     yawol.stackit.cloud/logForwardLokiURL: "http://example.com:3100/loki/api/v1/push"
-    # defines the TCP idle Timeout in seconds, default is 3600
-    yawol.stackit.cloud/tcpIdleTimeout: "300"
-    # defines the UDP idle Timeout in seconds, default is 60
-    yawol.stackit.cloud/udpIdleTimeout: "300"
+    # defines the TCP idle Timeout as duration, default is 1h
+    # make sure there is a valid unit (like "s", "m", "h"), otherwise this option is ignored
+    yawol.stackit.cloud/tcpIdleTimeout: "5m30s"
+    # defines the UDP idle Timeout as duration, default is 1m
+    # make sure there is a valid unit (like "s", "m", "h"), otherwise this option is ignored
+    yawol.stackit.cloud/udpIdleTimeout: "5m"
 ```
 
 See [our example service](example-setup/yawol-cloud-controller/service.yaml)

--- a/api/v1beta1/loadbalancer_types.go
+++ b/api/v1beta1/loadbalancer_types.go
@@ -110,14 +110,14 @@ type LoadBalancerOptions struct {
 	TCPProxyProtocolPortsFilter []int32 `json:"tcpProxyProtocolPortFilter,omitempty"`
 	// TCPIdleTimeout sets TCP idle Timeout for all TCP connections from this LoadBalancer.
 	// Value is in Seconds. With 0 you disable the idle timeout, be careful this can lead to side effects.
-	// Default is 3600s (1 hour).
+	// Default is 1h.
 	// +optional
-	TCPIdleTimeout *int `json:"tcpIdleTimeout,omitempty"`
+	TCPIdleTimeout *metav1.Duration `json:"tcpIdleTimeout,omitempty"`
 	// UDPIdleTimeout sets UDP idle Timeout for all UDP connections from this LoadBalancer.
 	// Value is in Seconds. With 0 you disable the idle timeout, be careful this can lead to side effects.
-	// Default is 60s (1 minute).
+	// Default is 1m.
 	// +optional
-	UDPIdleTimeout *int `json:"udpIdleTimeout,omitempty"`
+	UDPIdleTimeout *metav1.Duration `json:"udpIdleTimeout,omitempty"`
 	// LogForward enables log forward to a loki instance
 	// +optional
 	LogForward LoadBalancerLogForward `json:"logForward,omitempty"`

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -7,6 +7,7 @@ package v1beta1
 
 import (
 	"k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -350,12 +351,12 @@ func (in *LoadBalancerOptions) DeepCopyInto(out *LoadBalancerOptions) {
 	}
 	if in.TCPIdleTimeout != nil {
 		in, out := &in.TCPIdleTimeout, &out.TCPIdleTimeout
-		*out = new(int)
+		*out = new(metav1.Duration)
 		**out = **in
 	}
 	if in.UDPIdleTimeout != nil {
 		in, out := &in.UDPIdleTimeout, &out.UDPIdleTimeout
-		*out = new(int)
+		*out = new(metav1.Duration)
 		**out = **in
 	}
 	out.LogForward = in.LogForward

--- a/charts/yawol-controller/crds/yawol.stackit.cloud_loadbalancers.yaml
+++ b/charts/yawol-controller/crds/yawol.stackit.cloud_loadbalancers.yaml
@@ -187,7 +187,7 @@ spec:
                       connections from this LoadBalancer. Value is in Seconds. With
                       0 you disable the idle timeout, be careful this can lead to
                       side effects. Default is 3600s (1 hour).
-                    type: integer
+                    type: string
                   tcpProxyProtocol:
                     description: TCPProxyProtocol enables HAProxy TCP Proxy Protocol
                     type: boolean
@@ -204,7 +204,7 @@ spec:
                       connections from this LoadBalancer. Value is in Seconds. With
                       0 you disable the idle timeout, be careful this can lead to
                       side effects. Default is 60s (1 minute).
-                    type: integer
+                    type: string
                 type: object
               ports:
                 description: Ports defines the Ports for the LoadBalancer (copy from

--- a/controllers/yawol-cloud-controller/targetcontroller/service_controller.go
+++ b/controllers/yawol-cloud-controller/targetcontroller/service_controller.go
@@ -213,7 +213,7 @@ func (r *ServiceReconciler) createLoadBalancer(
 				},
 			},
 			DebugSettings: helper.GetDebugSettings(svc),
-			Options:       helper.GetOptions(svc),
+			Options:       helper.GetOptions(svc, r.Recorder),
 		},
 		Status: yawolv1beta1.LoadBalancerStatus{},
 	}
@@ -353,7 +353,7 @@ func (r *ServiceReconciler) reconcileOptions(
 	lb *yawolv1beta1.LoadBalancer,
 	svc *coreV1.Service,
 ) error {
-	newOptions := helper.GetOptions(svc)
+	newOptions := helper.GetOptions(svc, r.Recorder)
 	if !reflect.DeepEqual(newOptions.LoadBalancerSourceRanges, lb.Spec.Options.LoadBalancerSourceRanges) {
 		if err := r.patchLoadBalancerSourceRanges(ctx, lb, newOptions.LoadBalancerSourceRanges); err != nil {
 			r.Log.WithValues("service", svc.Name).Error(err, "could not patch loadbalancer.spec.options.LoadBalancerSourceRanges")

--- a/internal/helper/loadbalancer.go
+++ b/internal/helper/loadbalancer.go
@@ -337,11 +337,11 @@ func parseLoadBalancerInfoMetric(
 	}
 
 	if lb.Spec.Options.TCPIdleTimeout != nil {
-		labels["tcpIdleTimeout"] = strconv.Itoa(*lb.Spec.Options.TCPIdleTimeout)
+		labels["tcpIdleTimeout"] = lb.Spec.Options.TCPIdleTimeout.String()
 	}
 
 	if lb.Spec.Options.UDPIdleTimeout != nil {
-		labels["udpIdleTimeout"] = strconv.Itoa(*lb.Spec.Options.UDPIdleTimeout)
+		labels["udpIdleTimeout"] = lb.Spec.Options.UDPIdleTimeout.String()
 	}
 
 	loadbalancerInfoMetric.DeletePartialMatch(map[string]string{"lb": lb.Name, "namespace": lb.Namespace})

--- a/internal/helper/yawollet.go
+++ b/internal/helper/yawollet.go
@@ -13,6 +13,7 @@ import (
 	"github.com/golang/protobuf/ptypes/duration"
 	"github.com/golang/protobuf/ptypes/wrappers"
 	"google.golang.org/protobuf/types/known/anypb"
+	"google.golang.org/protobuf/types/known/durationpb"
 	corev1 "k8s.io/api/core/v1"
 	rbac "k8s.io/api/rbac/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -301,7 +302,7 @@ func createEnvoyTCPListener(
 	var idleTimeout *duration.Duration
 
 	if lb.Spec.Options.TCPIdleTimeout != nil {
-		idleTimeout = &duration.Duration{Seconds: int64(*lb.Spec.Options.TCPIdleTimeout)}
+		idleTimeout = durationpb.New(lb.Spec.Options.TCPIdleTimeout.Duration)
 	}
 
 	listenPort, err := anypb.New(&envoytcp.TcpProxy{
@@ -371,7 +372,7 @@ func createEnvoyUDPListener(
 
 	var idleTimeout *duration.Duration
 	if lb.Spec.Options.UDPIdleTimeout != nil {
-		idleTimeout = &duration.Duration{Seconds: int64(*lb.Spec.Options.UDPIdleTimeout)}
+		idleTimeout = durationpb.New(lb.Spec.Options.UDPIdleTimeout.Duration)
 	}
 
 	listenPort, err := anypb.New(&envoyudp.UdpProxyConfig{


### PR DESCRIPTION
Change the type of the new fields udpIdleTimeout and tcpIdleTimeout. 
There where no new version since the merge, so it should be no problem to change it in the API.


Related #70  https://github.com/stackitcloud/yawol/pull/70#discussion_r1030761969

CC: @nightlyone