### PR TITLE
Allow injecting generic-token-kubeconfig secret name into yawol-cloud-controller

### DIFF
--- a/charts/yawol-controller/templates/yawol-cloud-controller.yaml
+++ b/charts/yawol-controller/templates/yawol-cloud-controller.yaml
@@ -77,8 +77,11 @@ spec:
         resources:
 {{ toYaml .Values.resources.yawolCloudController | indent 10 }}
         {{- end }}
-{{- if .Values.yawolCloudController.additionalVolumeMounts }}
         volumeMounts:
+        - mountPath: /var/run/secrets/gardener.cloud/shoot/generic-kubeconfig
+          name: kubeconfig
+          readOnly: true
+{{- if .Values.yawolCloudController.additionalVolumeMounts }}
 {{ toYaml .Values.yawolCloudController.additionalVolumeMounts | indent 8 }}
 {{- end }}
         securityContext:
@@ -89,8 +92,24 @@ spec:
               - ALL
       dnsPolicy: ClusterFirst
       restartPolicy: Always
-{{- if .Values.yawolCloudController.additionalVolumes }}
       volumes:
+      - name: kubeconfig
+        projected:
+          defaultMode: 420
+          sources:
+          - secret:
+              items:
+              - key: kubeconfig
+                path: kubeconfig
+              name: {{ .Values.genericTokenKubeconfigSecretName }}
+              optional: false
+          - secret:
+              items:
+              - key: token
+                path: token
+              name: shoot-access-cloud-controller-manager
+              optional: false
+{{- if .Values.yawolCloudController.additionalVolumes }}
 {{ toYaml .Values.yawolCloudController.additionalVolumes | indent 6 }}
 {{- end }}
 {{- end }}

--- a/charts/yawol-controller/values.yaml
+++ b/charts/yawol-controller/values.yaml
@@ -17,27 +17,8 @@ yawolCloudController:
   clusterRoleEnabled: true
   additionalArguments:
     - -target-kubeconfig=/var/run/secrets/gardener.cloud/shoot/generic-kubeconfig/kubeconfig
-  additionalVolumes:
-    - name: kubeconfig
-      projected:
-        defaultMode: 420
-        sources:
-        - secret:
-            items:
-            - key: kubeconfig
-              path: kubeconfig
-            name: generic-token-kubeconfig
-            optional: false
-        - secret:
-            items:
-            - key: token
-              path: token
-            name: shoot-access-cloud-controller-manager
-            optional: false
-  additionalVolumeMounts:
-    - mountPath: /var/run/secrets/gardener.cloud/shoot/generic-kubeconfig
-      name: kubeconfig
-      readOnly: true
+  additionalVolumes: []
+  additionalVolumeMounts: []
   image:
     repository: ghcr.io/stackitcloud/yawol/yawol-cloud-controller
     tag: latest
@@ -117,3 +98,5 @@ yawolAvailabilityZone: ""
 
 # URL/IP of the Kubernetes API server that contains the LoadBalancer resources
 yawolAPIHost:
+
+genericTokenKubeconfigSecretName: generic-token-kubeconfig


### PR DESCRIPTION
With gardener v1.59.0+, there is no secret with the name `generic-token-kubeconfig` in the shoot control plane anymore (ref https://github.com/gardener/gardener/pull/6891/commits/2d1aa0912086c628ba735014e96e8b47c529bcf8).
It has been replaced by an immutable secret with a suffix that is managed by the secrets manager (ref https://github.com/gardener/gardener/pull/5510).
Extensions need to use the `extensionscontroller.GenericTokenKubeconfigSecretNameFromCluster` helper to retrieve the secret name of the currently active `generic-token-kubeconfig` secret name.
This needs to be injected into the `yawol-cloud-controller` deployment.

Accordingly, this PR changes the chart's structure and values to allow the injection of the secret name.
