### PR TITLE
Disable VPA by default

### DIFF
--- a/charts/yawol-controller/values.yaml
+++ b/charts/yawol-controller/values.yaml
@@ -5,7 +5,7 @@ featureGates: {}
 proxy: {}
 namespace: kube-system
 vpa:
-  enabled: true
+  enabled: false
   yawolCloudController:
     mode: Auto
   yawolController:


### PR DESCRIPTION
Disable VPA by default to avoid problem when it's not installed. Fixes #99 