### PR TITLE
add project-name, project-id, domain-id to the auth-config as well as keeping support for legacy tenant-name

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,8 @@ The in-cluster components of yawol (`yawol-cloud-controller` and
    the correct permission to be able to create instances and request floating
    IPs.
 
+**Note**: At most one of `domain-id` or `domain-name` and `project-id` or `project-name` must be provided.
+
    ```yaml
    apiVersion: v1
    kind: Secret
@@ -104,8 +106,11 @@ The in-cluster components of yawol (`yawol-cloud-controller` and
        [Global]
        auth-url="""
        domain-name=""
+       domain-id=""
+       # Deprecated (tenant-name): Please use project-name
        tenant-name=""
        project-name=""
+       project-id=""
        username=""
        password=""
        region=""

--- a/internal/openstack/client.go
+++ b/internal/openstack/client.go
@@ -229,7 +229,6 @@ func getProvider(
 
 	legacyProjectName := strings.TrimSpace(cfg.Section("Global").Key("tenant-name").String())
 	projectName := strings.TrimSpace(cfg.Section("Global").Key("project-name").String())
-	authInfo.ProjectName = strings.TrimSpace(cfg.Section("Global").Key("project-name").String())
 	authInfo.ProjectID = strings.TrimSpace(cfg.Section("Global").Key("project-id").String())
 
 	// TODO: remove legacyProjectName once openstack-cloud-controller has dropped tenant-name support. Link to ccm args:

--- a/internal/openstack/client.go
+++ b/internal/openstack/client.go
@@ -223,8 +223,23 @@ func getProvider(
 	authInfo.AuthURL = authURL
 	authInfo.Username = strings.TrimSpace(cfg.Section("Global").Key("username").String())
 	authInfo.Password = strings.TrimSpace(cfg.Section("Global").Key("password").String())
+
 	authInfo.DomainName = strings.TrimSpace(cfg.Section("Global").Key("domain-name").String())
-	authInfo.ProjectName = strings.TrimSpace(cfg.Section("Global").Key("tenant-name").String())
+	authInfo.DomainID = strings.TrimSpace(cfg.Section("Global").Key("domain-id").String())
+
+	legacyProjectName := strings.TrimSpace(cfg.Section("Global").Key("tenant-name").String())
+	projectName := strings.TrimSpace(cfg.Section("Global").Key("project-name").String())
+	authInfo.ProjectName = strings.TrimSpace(cfg.Section("Global").Key("project-name").String())
+	authInfo.ProjectID = strings.TrimSpace(cfg.Section("Global").Key("project-id").String())
+
+	// TODO: remove legacyProjectName once openstack-cloud-controller has dropped tenant-name support. Link to ccm args:
+	//nolint:lll // link
+	// https://github.com/kubernetes/cloud-provider-openstack/blob/master/docs/openstack-cloud-controller-manager/using-openstack-cloud-controller-manager.md
+	if projectName != "" {
+		authInfo.ProjectName = projectName
+	} else {
+		authInfo.ProjectName = legacyProjectName
+	}
 
 	region := strings.TrimSpace(cfg.Section("Global").Key("region").String())
 


### PR DESCRIPTION
add project-name, project-id, domain-id to the auth-config as well as keeping support for legacy tenant-name

Issue: #102 