### PR TITLE
revert chart apiVersion to v1

### DIFF
--- a/charts/yawol-controller/Chart.yaml
+++ b/charts/yawol-controller/Chart.yaml
@@ -1,4 +1,4 @@
-apiVersion: v2
+apiVersion: v1
 description: Helm chart for yawol-controller
 name: yawol-controller
 sources:


### PR DESCRIPTION
`v2`  results in problems with the gardener controller installation.
We don't use `v2` features so it is fine for now to revert it

cc: @nschad 