### PR TITLE
Improve keepalived handling during updates

### DIFF
--- a/api/v1beta1/loadbalancerset_types.go
+++ b/api/v1beta1/loadbalancerset_types.go
@@ -48,6 +48,9 @@ type LoadBalancerSetStatus struct {
 	// AvailableReplicas are the current running replicas.
 	// +optional
 	AvailableReplicas *int `json:"availableReplicas,omitempty"`
+	// Conditions contains condition information for a LoadBalancerSet.
+	// +optional
+	Conditions []metav1.Condition `json:"conditions,omitempty"`
 	// ReadyReplicas are the current ready replicas.
 	// +optional
 	ReadyReplicas *int `json:"readyReplicas,omitempty"`

--- a/api/v1beta1/loadbalancerset_types.go
+++ b/api/v1beta1/loadbalancerset_types.go
@@ -11,6 +11,7 @@ import (
 // +kubebuilder:printcolumn:name="DESIRED",type=string,JSONPath=`.spec.replicas`
 // +kubebuilder:printcolumn:name="CURRENT",type=string,JSONPath=`.status.replicas`
 // +kubebuilder:printcolumn:name="READY",type=string,JSONPath=`.status.readyReplicas`
+// +kubebuilder:printcolumn:name="HasKeepalivedMaster",type=string,JSONPath=`.status.conditions[?(@.type=="HasKeepalivedMaster")].status`
 // +kubebuilder:printcolumn:name="AGE",type=date,JSONPath=`.metadata.creationTimestamp`
 
 // LoadBalancerSet is the Schema for the LoadBalancerSet's API.

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -529,6 +529,13 @@ func (in *LoadBalancerSetStatus) DeepCopyInto(out *LoadBalancerSetStatus) {
 		*out = new(int)
 		**out = **in
 	}
+	if in.Conditions != nil {
+		in, out := &in.Conditions, &out.Conditions
+		*out = make([]metav1.Condition, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
 	if in.ReadyReplicas != nil {
 		in, out := &in.ReadyReplicas, &out.ReadyReplicas
 		*out = new(int)

--- a/charts/yawol-controller/crds/yawol.stackit.cloud_loadbalancersets.yaml
+++ b/charts/yawol-controller/crds/yawol.stackit.cloud_loadbalancersets.yaml
@@ -289,6 +289,75 @@ spec:
               availableReplicas:
                 description: AvailableReplicas are the current running replicas.
                 type: integer
+              conditions:
+                description: Conditions contains condition information for a LoadBalancerSet.
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource. --- This struct is intended for direct
+                    use as an array at the field path .status.conditions.  For example,
+                    \n type FooStatus struct{ // Represents the observations of a
+                    foo's current state. // Known .status.conditions.type are: \"Available\",
+                    \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
+                    // +listType=map // +listMapKey=type Conditions []metav1.Condition
+                    `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
+                    protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition
+                        transitioned from one status to another. This should be when
+                        the underlying condition changed.  If that is not known, then
+                        using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human readable message indicating
+                        details about the transition. This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation
+                        that the condition was set based upon. For instance, if .metadata.generation
+                        is currently 12, but the .status.conditions[x].observedGeneration
+                        is 9, the condition is out of date with respect to the current
+                        state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: reason contains a programmatic identifier indicating
+                        the reason for the condition's last transition. Producers
+                        of specific condition types may define expected values and
+                        meanings for this field, and whether the values are considered
+                        a guaranteed API. The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        --- Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
               readyReplicas:
                 description: ReadyReplicas are the current ready replicas.
                 type: integer

--- a/charts/yawol-controller/crds/yawol.stackit.cloud_loadbalancersets.yaml
+++ b/charts/yawol-controller/crds/yawol.stackit.cloud_loadbalancersets.yaml
@@ -27,6 +27,9 @@ spec:
     - jsonPath: .status.readyReplicas
       name: READY
       type: string
+    - jsonPath: .status.conditions[?(@.type=="HasKeepalivedMaster")].status
+      name: HasKeepalivedMaster
+      type: string
     - jsonPath: .metadata.creationTimestamp
       name: AGE
       type: date

--- a/controllers/yawol-controller/loadbalancer/loadbalancer_controller.go
+++ b/controllers/yawol-controller/loadbalancer/loadbalancer_controller.go
@@ -982,7 +982,7 @@ func (r *Reconciler) reconcileLoadBalancerSet(
 	}
 
 	if !downscaled {
-		if !helper.LBSetContainsKeepalivedMaster(loadBalancerSet) {
+		if !helper.LBSetHasKeepalivedMaster(loadBalancerSet) {
 			return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
 		}
 		r.Log.Info("scale down all lbsets except of", "lbs", loadBalancerSet.Name)

--- a/controllers/yawol-controller/loadbalancer/loadbalancer_controller.go
+++ b/controllers/yawol-controller/loadbalancer/loadbalancer_controller.go
@@ -32,7 +32,6 @@ import (
 
 const (
 	DefaultRequeueTime = 10 * time.Millisecond
-	RevisionAnnotation = "loadbalancer.yawol.stackit.cloud/revision"
 	ServiceFinalizer   = "yawol.stackit.cloud/controller2"
 )
 

--- a/controllers/yawol-controller/loadbalancer/loadbalancer_controller.go
+++ b/controllers/yawol-controller/loadbalancer/loadbalancer_controller.go
@@ -983,6 +983,9 @@ func (r *Reconciler) reconcileLoadBalancerSet(
 	}
 
 	if !downscaled {
+		if !helper.LBSetContainsKeepalivedMaster(loadBalancerSet) {
+			return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
+		}
 		r.Log.Info("scale down all lbsets except of", "lbs", loadBalancerSet.Name)
 		return helper.ScaleDownAllLoadBalancerSetsForLBBut(ctx, r.Client, lb, loadBalancerSet.Name)
 	}

--- a/controllers/yawol-controller/loadbalancer/loadbalancer_controller_test.go
+++ b/controllers/yawol-controller/loadbalancer/loadbalancer_controller_test.go
@@ -318,7 +318,7 @@ var _ = Describe("loadbalancer controller", Serial, Ordered, func() {
 				Expect(k8sClient.Get(ctx, newLbs, &lbs)).Should(Succeed())
 				lbs.Status.Conditions = []metav1.Condition{
 					{
-						Type:               helper.ContainsKeepalivedMaster,
+						Type:               helper.HasKeepalivedMaster,
 						Status:             metav1.ConditionTrue,
 						LastTransitionTime: metav1.Time{Time: metav1.Now().Add(-120 * time.Second)},
 						Reason:             "ready",

--- a/controllers/yawol-controller/loadbalancer/loadbalancer_controller_test.go
+++ b/controllers/yawol-controller/loadbalancer/loadbalancer_controller_test.go
@@ -26,7 +26,6 @@ import (
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/pointer"
 	runtimeClient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -178,10 +177,7 @@ var _ = Describe("loadbalancer controller", Serial, Ordered, func() {
 		It("should create a loadbalancerset", func() {
 			hopefully(lbNN, func(g Gomega, act LB) error {
 				var lbsetList yawolv1beta1.LoadBalancerSetList
-				g.Expect(k8sClient.List(ctx, &lbsetList, &runtimeClient.ListOptions{
-					LabelSelector: labels.SelectorFromSet(lb.Spec.Selector.MatchLabels),
-				})).Should(Succeed())
-
+				g.Expect(k8sClient.List(ctx, &lbsetList, runtimeClient.MatchingLabels(lb.Spec.Selector.MatchLabels))).Should(Succeed())
 				g.Expect(len(lbsetList.Items)).Should(Equal(1))
 
 				// prevent later panic
@@ -206,10 +202,7 @@ var _ = Describe("loadbalancer controller", Serial, Ordered, func() {
 			By("waiting for lbset creation")
 			hopefully(lbNN, func(g Gomega, act LB) error {
 				var lbsetList yawolv1beta1.LoadBalancerSetList
-				g.Expect(k8sClient.List(ctx, &lbsetList, &runtimeClient.ListOptions{
-					LabelSelector: labels.SelectorFromSet(lb.Spec.Selector.MatchLabels),
-				})).Should(Succeed())
-
+				g.Expect(k8sClient.List(ctx, &lbsetList, runtimeClient.MatchingLabels(lb.Spec.Selector.MatchLabels))).Should(Succeed())
 				g.Expect(len(lbsetList.Items)).Should(Equal(1))
 
 				lbset := lbsetList.Items[0]
@@ -229,10 +222,7 @@ var _ = Describe("loadbalancer controller", Serial, Ordered, func() {
 			By("checking for a new lbset")
 			hopefully(lbNN, func(g Gomega, act LB) error {
 				var lbsetList yawolv1beta1.LoadBalancerSetList
-				g.Expect(k8sClient.List(ctx, &lbsetList, &runtimeClient.ListOptions{
-					LabelSelector: labels.SelectorFromSet(lb.Spec.Selector.MatchLabels),
-				})).Should(Succeed())
-
+				g.Expect(k8sClient.List(ctx, &lbsetList, runtimeClient.MatchingLabels(lb.Spec.Selector.MatchLabels))).Should(Succeed())
 				g.Expect(len(lbsetList.Items)).Should(Equal(2))
 
 				By("testing if the new set got a different hash")
@@ -255,10 +245,7 @@ var _ = Describe("loadbalancer controller", Serial, Ordered, func() {
 			By("waiting for lbset creation")
 			hopefully(lbNN, func(g Gomega, act LB) error {
 				var lbsetList yawolv1beta1.LoadBalancerSetList
-				g.Expect(k8sClient.List(ctx, &lbsetList, &runtimeClient.ListOptions{
-					LabelSelector: labels.SelectorFromSet(lb.Spec.Selector.MatchLabels),
-				})).Should(Succeed())
-
+				g.Expect(k8sClient.List(ctx, &lbsetList, runtimeClient.MatchingLabels(lb.Spec.Selector.MatchLabels))).Should(Succeed())
 				g.Expect(len(lbsetList.Items)).Should(Equal(1))
 				oldLbs = runtimeClient.ObjectKeyFromObject(&lbsetList.Items[0])
 				return nil
@@ -275,14 +262,11 @@ var _ = Describe("loadbalancer controller", Serial, Ordered, func() {
 			By("checking for a new lbset")
 			hopefully(lbNN, func(g Gomega, act LB) error {
 				var lbsetList yawolv1beta1.LoadBalancerSetList
-				g.Expect(k8sClient.List(ctx, &lbsetList, &runtimeClient.ListOptions{
-					LabelSelector: labels.SelectorFromSet(lb.Spec.Selector.MatchLabels),
-				})).Should(Succeed())
-
+				g.Expect(k8sClient.List(ctx, &lbsetList, runtimeClient.MatchingLabels(lb.Spec.Selector.MatchLabels))).Should(Succeed())
 				g.Expect(len(lbsetList.Items)).Should(Equal(2))
-				for i := range lbsetList.Items {
-					if lbsetList.Items[i].Annotations[helper.RevisionAnnotation] == "2" {
-						newLbs = runtimeClient.ObjectKeyFromObject(&lbsetList.Items[i])
+				for _, lbs := range lbsetList.Items {
+					if lbs.Annotations[helper.RevisionAnnotation] == "2" {
+						newLbs = runtimeClient.ObjectKeyFromObject(&lbs)
 					}
 				}
 				return nil
@@ -290,9 +274,7 @@ var _ = Describe("loadbalancer controller", Serial, Ordered, func() {
 
 			By("Make both lbsets available by patching status")
 			var lbsetList yawolv1beta1.LoadBalancerSetList
-			Expect(k8sClient.List(ctx, &lbsetList, &runtimeClient.ListOptions{
-				LabelSelector: labels.SelectorFromSet(lb.Spec.Selector.MatchLabels),
-			})).Should(Succeed())
+			Expect(k8sClient.List(ctx, &lbsetList, runtimeClient.MatchingLabels(lb.Spec.Selector.MatchLabels))).Should(Succeed())
 			for _, lbs := range lbsetList.Items {
 				patch := runtimeClient.MergeFrom(lbs.DeepCopy())
 				lbs.Status.ReadyReplicas = &lbs.Spec.Replicas
@@ -368,10 +350,7 @@ var _ = Describe("loadbalancer controller", Serial, Ordered, func() {
 			By("waiting for lb and lbset creation")
 			hopefully(lbNN, func(g Gomega, act LB) error {
 				var lbsetList yawolv1beta1.LoadBalancerSetList
-				g.Expect(k8sClient.List(ctx, &lbsetList, &runtimeClient.ListOptions{
-					LabelSelector: labels.SelectorFromSet(lb.Spec.Selector.MatchLabels),
-				})).Should(Succeed())
-
+				g.Expect(k8sClient.List(ctx, &lbsetList, runtimeClient.MatchingLabels(lb.Spec.Selector.MatchLabels))).Should(Succeed())
 				g.Expect(len(lbsetList.Items)).Should(Equal(1))
 
 				lbset := lbsetList.Items[0]
@@ -386,10 +365,7 @@ var _ = Describe("loadbalancer controller", Serial, Ordered, func() {
 
 			Eventually(func(g Gomega) {
 				var lbsetList yawolv1beta1.LoadBalancerSetList
-				g.Expect(k8sClient.List(ctx, &lbsetList, &runtimeClient.ListOptions{
-					LabelSelector: labels.SelectorFromSet(lb.Spec.Selector.MatchLabels),
-				})).Should(Succeed())
-
+				g.Expect(k8sClient.List(ctx, &lbsetList, runtimeClient.MatchingLabels(lb.Spec.Selector.MatchLabels))).Should(Succeed())
 				g.Expect(len(lbsetList.Items)).Should(Equal(1))
 
 				lbset := lbsetList.Items[0]
@@ -403,10 +379,7 @@ var _ = Describe("loadbalancer controller", Serial, Ordered, func() {
 
 			Eventually(func(g Gomega) {
 				var lbsetList yawolv1beta1.LoadBalancerSetList
-				g.Expect(k8sClient.List(ctx, &lbsetList, &runtimeClient.ListOptions{
-					LabelSelector: labels.SelectorFromSet(lb.Spec.Selector.MatchLabels),
-				})).Should(Succeed())
-
+				g.Expect(k8sClient.List(ctx, &lbsetList, runtimeClient.MatchingLabels(lb.Spec.Selector.MatchLabels))).Should(Succeed())
 				g.Expect(len(lbsetList.Items)).Should(Equal(1))
 
 				lbset := lbsetList.Items[0]

--- a/controllers/yawol-controller/loadbalancer/loadbalancerset_status_controller.go
+++ b/controllers/yawol-controller/loadbalancer/loadbalancerset_status_controller.go
@@ -57,7 +57,7 @@ func (r *LoadBalancerSetStatusReconciler) Reconcile(ctx context.Context, req ctr
 	}
 
 	// Not the current revision
-	if lb.Annotations[RevisionAnnotation] != loadBalancerSet.Annotations[RevisionAnnotation] {
+	if lb.Annotations[helper.RevisionAnnotation] != loadBalancerSet.Annotations[helper.RevisionAnnotation] {
 		return ctrl.Result{}, nil
 	}
 

--- a/controllers/yawol-controller/loadbalancerset/loadbalancerset_controller.go
+++ b/controllers/yawol-controller/loadbalancerset/loadbalancerset_controller.go
@@ -3,7 +3,6 @@ package loadbalancerset
 import (
 	"context"
 	"crypto/rand"
-	"encoding/json"
 	"fmt"
 	"time"
 
@@ -19,7 +18,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/utils/pointer"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -157,7 +155,6 @@ func (r *LoadBalancerSetReconciler) patchStatus(
 	readyMachinesCount int,
 	hasKeepalivedMaster bool,
 ) (ctrl.Result, error) {
-
 	setCopy := set.DeepCopy()
 
 	// Write replicas into status
@@ -242,19 +239,6 @@ func findFirstMachineForDeletion(machines []yawolv1beta1.LoadBalancerMachine) (y
 		return yawolv1beta1.LoadBalancerMachine{}, helper.ErrNoLBMFoundForScaleDown
 	}
 	return machines[0], nil
-}
-
-func (r *LoadBalancerSetReconciler) patchLoadBalancerSetStatus(
-	ctx context.Context,
-	lbs *yawolv1beta1.LoadBalancerSet,
-	status yawolv1beta1.LoadBalancerSetStatus,
-) error {
-	statusJSON, err := json.Marshal(status)
-	if err != nil {
-		return err
-	}
-	patch := []byte(`{"status":` + string(statusJSON) + `}`)
-	return r.Client.Status().Patch(ctx, lbs, client.RawPatch(types.MergePatchType, patch))
 }
 
 // Decides whether the machine should be deleted or not

--- a/controllers/yawol-controller/loadbalancerset/loadbalancerset_controller.go
+++ b/controllers/yawol-controller/loadbalancerset/loadbalancerset_controller.go
@@ -15,7 +15,7 @@ import (
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -177,22 +177,22 @@ func (r *LoadBalancerSetReconciler) reconcileStatus(
 	}
 
 	// Write set contains master condition
-	status := v1.ConditionFalse
+	status := metav1.ConditionFalse
 	reason := "NoKeepalivedMasterInSet"
 
 	if setContainsMaster {
-		status = v1.ConditionTrue
+		status = metav1.ConditionTrue
 		reason = "KeepalivedMasterInSet"
 	}
 
-	transitionTime := v1.Now()
+	transitionTime := metav1.Now()
 	for _, condition := range set.Status.Conditions {
 		if condition.Type == helper.ContainsKeepalivedMaster && condition.Status == status {
 			transitionTime = condition.LastTransitionTime
 		}
 	}
 
-	conditions := []v1.Condition{
+	conditions := []metav1.Condition{
 		{
 			Type:               helper.ContainsKeepalivedMaster,
 			Status:             status,
@@ -283,8 +283,8 @@ func (r *LoadBalancerSetReconciler) patchLoadBalancerSetStatus(
 // True if LastHeartbeatTime is > 5 minutes
 // True if a condition is not good for 5 minutes
 func shouldMachineBeDeleted(machine yawolv1beta1.LoadBalancerMachine) (bool, error) {
-	before5Minutes := v1.Time{Time: time.Now().Add(-5 * time.Minute)}
-	before10Minutes := v1.Time{Time: time.Now().Add(-10 * time.Minute)}
+	before5Minutes := metav1.Time{Time: time.Now().Add(-5 * time.Minute)}
+	before10Minutes := metav1.Time{Time: time.Now().Add(-10 * time.Minute)}
 
 	// to handle the initial 10 minutes
 	if machine.CreationTimestamp.Before(&before10Minutes) &&
@@ -325,7 +325,7 @@ func shouldMachineBeDeleted(machine yawolv1beta1.LoadBalancerMachine) (bool, err
 // False if LastHeartbeatTime is older than 180sec
 // False if ConfigReady, EnvoyReady or EnvoyUpToDate are false
 func isMachineReady(machine yawolv1beta1.LoadBalancerMachine) bool {
-	before180seconds := v1.Time{Time: time.Now().Add(-180 * time.Second)}
+	before180seconds := metav1.Time{Time: time.Now().Add(-180 * time.Second)}
 
 	// not ready if no conditions are available
 	if machine.Status.Conditions == nil || len(*machine.Status.Conditions) < 6 {
@@ -362,10 +362,10 @@ func (r *LoadBalancerSetReconciler) createMachine(ctx context.Context, set *yawo
 	machineLabels := r.getMachineLabelsFromSet(set)
 	revision := set.Annotations[helper.RevisionAnnotation]
 	machine := yawolv1beta1.LoadBalancerMachine{
-		ObjectMeta: v1.ObjectMeta{
+		ObjectMeta: metav1.ObjectMeta{
 			Name:      set.Name + "-" + randomString(5),
 			Namespace: set.Namespace,
-			OwnerReferences: []v1.OwnerReference{
+			OwnerReferences: []metav1.OwnerReference{
 				{
 					APIVersion: set.APIVersion,
 					Kind:       set.Kind,

--- a/controllers/yawol-controller/loadbalancerset/loadbalancerset_controller.go
+++ b/controllers/yawol-controller/loadbalancerset/loadbalancerset_controller.go
@@ -309,6 +309,7 @@ func isMachineReady(machine yawolv1beta1.LoadBalancerMachine) bool {
 
 func (r *LoadBalancerSetReconciler) createMachine(ctx context.Context, set *yawolv1beta1.LoadBalancerSet) error {
 	machineLabels := r.getMachineLabelsFromSet(set)
+	revision := set.Annotations[helper.RevisionAnnotation]
 	machine := yawolv1beta1.LoadBalancerMachine{
 		ObjectMeta: v1.ObjectMeta{
 			Name:      set.Name + "-" + randomString(5),
@@ -322,6 +323,9 @@ func (r *LoadBalancerSetReconciler) createMachine(ctx context.Context, set *yawo
 				},
 			},
 			Labels: machineLabels,
+			Annotations: map[string]string{
+				helper.RevisionAnnotation: revision,
+			},
 		},
 		Spec: set.Spec.Template.Spec,
 	}

--- a/controllers/yawol-controller/loadbalancerset/loadbalancerset_controller.go
+++ b/controllers/yawol-controller/loadbalancerset/loadbalancerset_controller.go
@@ -86,7 +86,7 @@ func (r *LoadBalancerSetReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 			deletedMachineCount++
 			continue
 		}
-		if isMachineMaster(childMachines.Items[i]) {
+		if isMachineKeepalivedMaster(childMachines.Items[i]) {
 			hasKeepalivedMaster = true
 		}
 
@@ -326,7 +326,7 @@ func isMachineReady(machine yawolv1beta1.LoadBalancerMachine) bool {
 	return true
 }
 
-func isMachineMaster(machine yawolv1beta1.LoadBalancerMachine) bool {
+func isMachineKeepalivedMaster(machine yawolv1beta1.LoadBalancerMachine) bool {
 	if machine.Status.Conditions != nil {
 		for _, condition := range *machine.Status.Conditions {
 			if condition.Type == corev1.NodeConditionType(helper.KeepalivedMaster) {
@@ -339,7 +339,6 @@ func isMachineMaster(machine yawolv1beta1.LoadBalancerMachine) bool {
 
 func (r *LoadBalancerSetReconciler) createMachine(ctx context.Context, set *yawolv1beta1.LoadBalancerSet) error {
 	machineLabels := r.getMachineLabelsFromSet(set)
-	revision := set.Annotations[helper.RevisionAnnotation]
 	machine := yawolv1beta1.LoadBalancerMachine{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      set.Name + "-" + randomString(5),
@@ -354,7 +353,7 @@ func (r *LoadBalancerSetReconciler) createMachine(ctx context.Context, set *yawo
 			},
 			Labels: machineLabels,
 			Annotations: map[string]string{
-				helper.RevisionAnnotation: revision,
+				helper.RevisionAnnotation: set.Annotations[helper.RevisionAnnotation],
 			},
 		},
 		Spec: set.Spec.Template.Spec,

--- a/controllers/yawol-controller/loadbalancerset/loadbalancerset_controller_test.go
+++ b/controllers/yawol-controller/loadbalancerset/loadbalancerset_controller_test.go
@@ -109,6 +109,7 @@ var _ = Describe("LoadBalancerSet controller", Serial, Ordered, func() {
 		It("Should eventually have a master", func() {
 			By("setting LBM as master")
 			machine := getChildMachines(ctx, &setStub)[0]
+			patch := client.MergeFrom(machine.DeepCopy())
 			machine.Status.Conditions = &[]v1.NodeCondition{
 				{
 					Type:   v1.NodeConditionType(helper.KeepalivedMaster),
@@ -116,7 +117,7 @@ var _ = Describe("LoadBalancerSet controller", Serial, Ordered, func() {
 					Reason: "KeepalivedStatus",
 				},
 			}
-			Expect(k8sClient.Status().Update(ctx, &machine)).To(Succeed())
+			Expect(k8sClient.Status().Patch(ctx, &machine, patch)).To(Succeed())
 
 			Eventually(func() metav1.ConditionStatus {
 				var set yawolv1beta1.LoadBalancerSet
@@ -155,8 +156,9 @@ var _ = Describe("LoadBalancerSet controller", Serial, Ordered, func() {
 		It("Should be successfully", func() {
 			childMachines := getChildMachines(ctx, &setStub)
 			for _, machine := range childMachines {
+				patch := client.MergeFrom(machine.DeepCopy())
 				machine.Status.Conditions = &cpy
-				err := k8sClient.Status().Update(ctx, &machine)
+				err := k8sClient.Status().Patch(ctx, &machine, patch)
 				Expect(err).NotTo(HaveOccurred())
 			}
 		})
@@ -185,8 +187,9 @@ var _ = Describe("LoadBalancerSet controller", Serial, Ordered, func() {
 			childMachines := getChildMachines(ctx, &setStub)
 
 			for _, machine := range childMachines {
+				patch := client.MergeFrom(machine.DeepCopy())
 				machine.Status.Conditions = &conditions
-				err := k8sClient.Status().Update(ctx, &machine)
+				err := k8sClient.Status().Patch(ctx, &machine, patch)
 				Expect(err).NotTo(HaveOccurred())
 			}
 		})

--- a/controllers/yawol-controller/loadbalancerset/loadbalancerset_controller_test.go
+++ b/controllers/yawol-controller/loadbalancerset/loadbalancerset_controller_test.go
@@ -123,7 +123,7 @@ var _ = Describe("LoadBalancerSet controller", Serial, Ordered, func() {
 				Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(&setStub), &set)).To(Succeed())
 				Expect(set.Status.Conditions).To(Not(BeNil()))
 				for _, condition := range set.Status.Conditions {
-					if condition.Type == helper.ContainsKeepalivedMaster {
+					if condition.Type == helper.HasKeepalivedMaster {
 						return condition.Status
 					}
 				}

--- a/controllers/yawollet/loadbalancer_controller.go
+++ b/controllers/yawollet/loadbalancer_controller.go
@@ -93,6 +93,10 @@ func (r *LoadBalancerReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		return ctrl.Result{}, err
 	}
 
+	if err := helper.UpdateKeepalivedFile(lb, lbm); err != nil {
+		return ctrl.Result{}, err
+	}
+
 	return ctrl.Result{RequeueAfter: time.Duration(r.RequeueTime) * time.Second}, reconcileError
 }
 

--- a/controllers/yawollet/loadbalancer_controller_test.go
+++ b/controllers/yawollet/loadbalancer_controller_test.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"io/fs"
 	"net/http"
-	"os"
 	"os/exec"
 	"strings"
 	"time"
@@ -453,7 +452,7 @@ var _ = Describe("check loadbalancer reconcile", Serial, Ordered, func() {
 		When("lb and lbm revision annotation are the same", func() {
 			It("should create yawolKeepalivedFile", func() {
 				Eventually(func() error {
-					_, err := os.Stat(helper.YawolKeepalivedFile)
+					_, err := aferoFs.Stat(helper.YawolKeepalivedFile)
 					return err
 				}, TIMEOUT, INTERVAL).Should(Succeed())
 
@@ -467,7 +466,7 @@ var _ = Describe("check loadbalancer reconcile", Serial, Ordered, func() {
 			})
 			It("should not create or delete yawolKeepalivedFile", func() {
 				Eventually(func() error {
-					_, err := os.Stat(helper.YawolKeepalivedFile)
+					_, err := aferoFs.Stat(helper.YawolKeepalivedFile)
 					if err == nil || !errors.Is(err, fs.ErrNotExist) {
 						return errors.New("keepalived file still exists")
 					}

--- a/controllers/yawollet/loadbalancer_controller_test.go
+++ b/controllers/yawollet/loadbalancer_controller_test.go
@@ -452,7 +452,7 @@ var _ = Describe("check loadbalancer reconcile", Serial, Ordered, func() {
 		When("lb and lbm revision annotation are the same", func() {
 			It("should create yawolKeepalivedFile", func() {
 				Eventually(func() error {
-					_, err := filesystem.Stat(helper.YawolKeepalivedFile)
+					_, err := filesystem.Stat(helper.YawolSetIsLatestRevisionFile)
 					return err
 				}, TIMEOUT, INTERVAL).Should(Succeed())
 
@@ -466,7 +466,7 @@ var _ = Describe("check loadbalancer reconcile", Serial, Ordered, func() {
 			})
 			It("should not create or delete yawolKeepalivedFile", func() {
 				Eventually(func() error {
-					_, err := filesystem.Stat(helper.YawolKeepalivedFile)
+					_, err := filesystem.Stat(helper.YawolSetIsLatestRevisionFile)
 					if err == nil || !errors.Is(err, fs.ErrNotExist) {
 						return errors.New("keepalived file still exists")
 					}

--- a/controllers/yawollet/loadbalancer_controller_test.go
+++ b/controllers/yawollet/loadbalancer_controller_test.go
@@ -452,7 +452,7 @@ var _ = Describe("check loadbalancer reconcile", Serial, Ordered, func() {
 		When("lb and lbm revision annotation are the same", func() {
 			It("should create yawolKeepalivedFile", func() {
 				Eventually(func() error {
-					_, err := aferoFs.Stat(helper.YawolKeepalivedFile)
+					_, err := filesystem.Stat(helper.YawolKeepalivedFile)
 					return err
 				}, TIMEOUT, INTERVAL).Should(Succeed())
 
@@ -466,7 +466,7 @@ var _ = Describe("check loadbalancer reconcile", Serial, Ordered, func() {
 			})
 			It("should not create or delete yawolKeepalivedFile", func() {
 				Eventually(func() error {
-					_, err := aferoFs.Stat(helper.YawolKeepalivedFile)
+					_, err := filesystem.Stat(helper.YawolKeepalivedFile)
 					if err == nil || !errors.Is(err, fs.ErrNotExist) {
 						return errors.New("keepalived file still exists")
 					}

--- a/controllers/yawollet/suite_test.go
+++ b/controllers/yawollet/suite_test.go
@@ -43,13 +43,13 @@ const (
 )
 
 var (
-	cfg       *rest.Config
-	k8sClient client.Client
-	testEnv   *envtest.Environment
-	envoyCmd  *exec.Cmd
-	ctx       context.Context
-	cancel    context.CancelFunc
-	aferoFs   afero.Fs
+	cfg        *rest.Config
+	k8sClient  client.Client
+	testEnv    *envtest.Environment
+	envoyCmd   *exec.Cmd
+	ctx        context.Context
+	cancel     context.CancelFunc
+	filesystem afero.Fs
 )
 
 func TestAPIs(t *testing.T) {
@@ -61,7 +61,7 @@ func TestAPIs(t *testing.T) {
 var _ = BeforeSuite(func() {
 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
 
-	aferoFs = afero.NewMemMapFs()
+	filesystem = afero.NewMemMapFs()
 
 	ctx, cancel = context.WithCancel(context.Background())
 
@@ -142,7 +142,7 @@ var _ = BeforeSuite(func() {
 		EnvoyCache:              cache,
 		ListenAddress:           "127.0.0.1",
 		RequeueTime:             1,
-		AferoFs:                 aferoFs,
+		Filesystem:              filesystem,
 	}).SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 

--- a/controllers/yawollet/suite_test.go
+++ b/controllers/yawollet/suite_test.go
@@ -18,6 +18,7 @@ import (
 	testv3 "github.com/envoyproxy/go-control-plane/pkg/test/v3"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/spf13/afero"
 	"google.golang.org/grpc"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
@@ -48,6 +49,7 @@ var (
 	envoyCmd  *exec.Cmd
 	ctx       context.Context
 	cancel    context.CancelFunc
+	aferoFs   afero.Fs
 )
 
 func TestAPIs(t *testing.T) {
@@ -58,6 +60,8 @@ func TestAPIs(t *testing.T) {
 
 var _ = BeforeSuite(func() {
 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
+
+	aferoFs = afero.NewMemMapFs()
 
 	ctx, cancel = context.WithCancel(context.Background())
 
@@ -138,6 +142,7 @@ var _ = BeforeSuite(func() {
 		EnvoyCache:              cache,
 		ListenAddress:           "127.0.0.1",
 		RequeueTime:             1,
+		AferoFs:                 aferoFs,
 	}).SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 

--- a/image/install-alpine.yaml
+++ b/image/install-alpine.yaml
@@ -79,6 +79,14 @@
         state: directory
         mode: '0755'
 
+    - name: Create a /var/lib directory for yawol
+      file:
+        path: /var/lib/yawol
+        owner: yawol
+        group: yawol
+        state: directory
+        mode: '0755'
+
     - name: add sudoers file for yawol
       copy:
         src: ./yawol-sudoers

--- a/internal/helper/const.go
+++ b/internal/helper/const.go
@@ -6,9 +6,10 @@ const (
 	OpenstackReconcileTime = 5 * time.Minute
 	DefaultRequeueTime     = 10 * time.Millisecond
 	RevisionAnnotation     = "loadbalancer.yawol.stackit.cloud/revision"
-	YawolKeepalivedFile    = "/tmp/yawolKeepalivedLastSet"
+	YawolKeepalivedDir     = "/var/yawol/"
+	YawolKeepalivedFile    = YawolKeepalivedDir + "set_is_latest_revision"
 	HashLabel              = "lbm-template-hash"
-	LoadBalancerKind       = "LoadBalancer"
+    LoadBalancerKind       = "LoadBalancer"
 	VRRPInstanceName       = "ENVOY"
-	HasKeepalivedMaster    = "HasKeepalivedMaster"
+    HasKeepalivedMaster    = "HasKeepalivedMaster"
 )

--- a/internal/helper/const.go
+++ b/internal/helper/const.go
@@ -3,12 +3,12 @@ package helper
 import "time"
 
 const (
-	OpenstackReconcileTime = 5 * time.Minute
-	DefaultRequeueTime     = 10 * time.Millisecond
-	RevisionAnnotation     = "loadbalancer.yawol.stackit.cloud/revision"
-	YawolKeepalivedFile    = "/tmp/yawolKeepalivedLastSet"
-	HashLabel              = "lbm-template-hash"
-	LoadBalancerKind       = "LoadBalancer"
-	VRRPInstanceName       = "ENVOY"
-	ContainsKeepAlivedMaster = "ContainsKeepAlivedMaster"
+	OpenstackReconcileTime   = 5 * time.Minute
+	DefaultRequeueTime       = 10 * time.Millisecond
+	RevisionAnnotation       = "loadbalancer.yawol.stackit.cloud/revision"
+	YawolKeepalivedFile      = "/tmp/yawolKeepalivedLastSet"
+	HashLabel                = "lbm-template-hash"
+	LoadBalancerKind         = "LoadBalancer"
+	VRRPInstanceName         = "ENVOY"
+	ContainsKeepalivedMaster = "ContainsKeepalivedMaster"
 )

--- a/internal/helper/const.go
+++ b/internal/helper/const.go
@@ -3,13 +3,13 @@ package helper
 import "time"
 
 const (
-	OpenstackReconcileTime = 5 * time.Minute
-	DefaultRequeueTime     = 10 * time.Millisecond
-	RevisionAnnotation     = "loadbalancer.yawol.stackit.cloud/revision"
-	YawolKeepalivedDir     = "/var/yawol/"
-	YawolKeepalivedFile    = YawolKeepalivedDir + "set_is_latest_revision"
-	HashLabel              = "lbm-template-hash"
-    LoadBalancerKind       = "LoadBalancer"
-	VRRPInstanceName       = "ENVOY"
-    HasKeepalivedMaster    = "HasKeepalivedMaster"
+	OpenstackReconcileTime       = 5 * time.Minute
+	DefaultRequeueTime           = 10 * time.Millisecond
+	RevisionAnnotation           = "loadbalancer.yawol.stackit.cloud/revision"
+	YawolLibDir                  = "/var/lib/yawol/"
+	YawolSetIsLatestRevisionFile = YawolLibDir + "set_is_latest_revision"
+	HashLabel                    = "lbm-template-hash"
+	LoadBalancerKind             = "LoadBalancer"
+	VRRPInstanceName             = "ENVOY"
+	HasKeepalivedMaster          = "HasKeepalivedMaster"
 )

--- a/internal/helper/const.go
+++ b/internal/helper/const.go
@@ -10,4 +10,5 @@ const (
 	HashLabel              = "lbm-template-hash"
 	LoadBalancerKind       = "LoadBalancer"
 	VRRPInstanceName       = "ENVOY"
+	ContainsKeepAlivedMaster = "ContainsKeepAlivedMaster"
 )

--- a/internal/helper/const.go
+++ b/internal/helper/const.go
@@ -3,12 +3,12 @@ package helper
 import "time"
 
 const (
-	OpenstackReconcileTime   = 5 * time.Minute
-	DefaultRequeueTime       = 10 * time.Millisecond
-	RevisionAnnotation       = "loadbalancer.yawol.stackit.cloud/revision"
-	YawolKeepalivedFile      = "/tmp/yawolKeepalivedLastSet"
-	HashLabel                = "lbm-template-hash"
-	LoadBalancerKind         = "LoadBalancer"
-	VRRPInstanceName         = "ENVOY"
-	ContainsKeepalivedMaster = "ContainsKeepalivedMaster"
+	OpenstackReconcileTime = 5 * time.Minute
+	DefaultRequeueTime     = 10 * time.Millisecond
+	RevisionAnnotation     = "loadbalancer.yawol.stackit.cloud/revision"
+	YawolKeepalivedFile    = "/tmp/yawolKeepalivedLastSet"
+	HashLabel              = "lbm-template-hash"
+	LoadBalancerKind       = "LoadBalancer"
+	VRRPInstanceName       = "ENVOY"
+	HasKeepalivedMaster    = "HasKeepalivedMaster"
 )

--- a/internal/helper/const.go
+++ b/internal/helper/const.go
@@ -6,6 +6,7 @@ const (
 	OpenstackReconcileTime = 5 * time.Minute
 	DefaultRequeueTime     = 10 * time.Millisecond
 	RevisionAnnotation     = "loadbalancer.yawol.stackit.cloud/revision"
+	YawolKeepalivedFile    = "/tmp/yawolKeepalivedLastSet"
 	HashLabel              = "lbm-template-hash"
 	LoadBalancerKind       = "LoadBalancer"
 	VRRPInstanceName       = "ENVOY"

--- a/internal/helper/loadbalancermachine.go
+++ b/internal/helper/loadbalancermachine.go
@@ -315,6 +315,7 @@ vrrp_track_process envoy {
 	weight 100
 }
 
+# the yawolfile is used to change priority if loadbalancermachine is from current revision
 vrrp_track_file yawolfile {
 	file "` + YawolKeepalivedFile + `"
 	weight 10

--- a/internal/helper/loadbalancermachine.go
+++ b/internal/helper/loadbalancermachine.go
@@ -317,7 +317,7 @@ vrrp_track_process envoy {
 
 # the yawolfile is used to change priority if loadbalancermachine is from current revision
 vrrp_track_file yawolfile {
-	file "` + YawolKeepalivedFile + `"
+	file "` + YawolSetIsLatestRevisionFile + `"
 	weight 10
 }
 

--- a/internal/helper/loadbalancermachine.go
+++ b/internal/helper/loadbalancermachine.go
@@ -315,6 +315,11 @@ vrrp_track_process envoy {
 	weight 100
 }
 
+vrrp_track_file yawolfile {
+	file "` + YawolKeepalivedFile + `"
+	weight 10
+}
+
 vrrp_instance ` + VRRPInstanceName + ` {
 	state BACKUP
 	interface eth0
@@ -334,6 +339,10 @@ vrrp_instance ` + VRRPInstanceName + ` {
 
 	track_process {
 		envoy
+	}
+
+	track_file {
+		yawolfile
 	}
 }`
 }

--- a/internal/helper/loadbalancermachine.go
+++ b/internal/helper/loadbalancermachine.go
@@ -316,7 +316,7 @@ vrrp_track_process envoy {
 }
 
 # the yawolfile is used to change priority if loadbalancermachine is from current revision
-vrrp_track_file yawolfile {
+track_file yawolfile {
 	file "` + YawolSetIsLatestRevisionFile + `"
 	weight 10
 }

--- a/internal/helper/loadbalancermachine.go
+++ b/internal/helper/loadbalancermachine.go
@@ -323,7 +323,6 @@ vrrp_track_file yawolfile {
 vrrp_instance ` + VRRPInstanceName + ` {
 	state BACKUP
 	interface eth0
-	nopreempt
 	virtual_router_id 100
 	priority 50
 	advert_int 4

--- a/internal/helper/loadbalancerset.go
+++ b/internal/helper/loadbalancerset.go
@@ -131,14 +131,14 @@ func LoadBalancerSetIsReady(
 	return false, fmt.Errorf("active LoadBalancerSet not found")
 }
 
-// LBSetContainsKeepalivedMaster returns true if the keepalived condition on set is ready for more than 2 min
+// LBSetHasKeepalivedMaster returns true if the keepalived condition on set is ready for more than 2 min
 // or keepalived is not ready for more than 10 min (to make sure this do not block updates)
-func LBSetContainsKeepalivedMaster(set *yawolv1beta1.LoadBalancerSet) bool {
+func LBSetHasKeepalivedMaster(set *yawolv1beta1.LoadBalancerSet) bool {
 	before2Minutes := metaV1.Time{Time: time.Now().Add(-2 * time.Minute)}
 	before10Minutes := metaV1.Time{Time: time.Now().Add(-10 * time.Minute)}
 
 	for _, condition := range set.Status.Conditions {
-		if condition.Type != ContainsKeepalivedMaster {
+		if condition.Type != HasKeepalivedMaster {
 			continue
 		}
 		if condition.Status == metaV1.ConditionTrue {

--- a/internal/helper/loadbalancerset.go
+++ b/internal/helper/loadbalancerset.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strconv"
+	"time"
 
 	v1 "k8s.io/api/core/v1"
 	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -128,6 +129,24 @@ func LoadBalancerSetIsReady(
 	}
 
 	return false, fmt.Errorf("active LoadBalancerSet not found")
+}
+
+// LBSetContainsKeepalivedMaster returns true if the keepalived condition on set is ready for more than 2 min
+// or keepalived is not ready for more than 10 min (to make sure this do not block updates)
+func LBSetContainsKeepalivedMaster(set *yawolv1beta1.LoadBalancerSet) bool {
+	before2Minutes := metaV1.Time{Time: time.Now().Add(-2 * time.Minute)}
+	before10Minutes := metaV1.Time{Time: time.Now().Add(-10 * time.Minute)}
+
+	for _, condition := range set.Status.Conditions {
+		if condition.Type != ContainsKeepalivedMaster {
+			continue
+		}
+		if condition.Status == metaV1.ConditionTrue {
+			return condition.LastTransitionTime.Before(&before2Minutes)
+		}
+		return condition.LastTransitionTime.Before(&before10Minutes)
+	}
+	return false
 }
 
 // Checks if LoadBalancerSets deriving from LoadBalancers are downscaled except for the LoadBalancerSet with the name of exceptionName

--- a/internal/helper/loadbalancerset.go
+++ b/internal/helper/loadbalancerset.go
@@ -131,11 +131,14 @@ func LoadBalancerSetIsReady(
 	return false, fmt.Errorf("active LoadBalancerSet not found")
 }
 
-// LBSetHasKeepalivedMaster returns true if the keepalived condition on set is ready for more than 2 min
-// or keepalived is not ready for more than 10 min (to make sure this do not block updates)
+// LBSetHasKeepalivedMaster returns true one of the following conditions are met:
+// - if the keepalived condition on set is ready for more than 2 min
+// - keepalived condition is not ready for more than 10 min (to make sure this does not block updates)
+// - no keepalived condition is in lbs but lbs is older than 15 min (to make sure this does not block updates)
 func LBSetHasKeepalivedMaster(set *yawolv1beta1.LoadBalancerSet) bool {
 	before2Minutes := metaV1.Time{Time: time.Now().Add(-2 * time.Minute)}
 	before10Minutes := metaV1.Time{Time: time.Now().Add(-10 * time.Minute)}
+	before15Minutes := metaV1.Time{Time: time.Now().Add(-15 * time.Minute)}
 
 	for _, condition := range set.Status.Conditions {
 		if condition.Type != HasKeepalivedMaster {
@@ -146,7 +149,7 @@ func LBSetHasKeepalivedMaster(set *yawolv1beta1.LoadBalancerSet) bool {
 		}
 		return condition.LastTransitionTime.Before(&before10Minutes)
 	}
-	return false
+	return set.CreationTimestamp.Before(&before15Minutes)
 }
 
 // Checks if LoadBalancerSets deriving from LoadBalancers are downscaled except for the LoadBalancerSet with the name of exceptionName

--- a/internal/helper/yawollet.go
+++ b/internal/helper/yawollet.go
@@ -446,7 +446,7 @@ func GetRoleRules(
 	loadBalancerMachine *yawolv1beta1.LoadBalancerMachine,
 ) []rbac.PolicyRule {
 	return []rbac.PolicyRule{{
-		Verbs:     []string{"create"},
+		Verbs:     []string{"create", "patch"},
 		APIGroups: []string{""},
 		Resources: []string{"events"},
 	}, {

--- a/internal/helper/yawollet.go
+++ b/internal/helper/yawollet.go
@@ -893,12 +893,14 @@ func EnableAdHocDebugging(
 
 func UpdateKeepalivedFile(lb *yawolv1beta1.LoadBalancer, lbm *yawolv1beta1.LoadBalancerMachine) error {
 	if lbmIsLatestRevision(lb, lbm) {
-		//file should exist
+		// file should exist
 		f, err := os.Create(YawolKeepalivedFile)
-		defer f.Close()
-		return err
+		if err != nil {
+			return err
+		}
+		return f.Close()
 	}
-	//file should not exist
+	// file should not exist
 	err := os.Remove(YawolKeepalivedFile)
 	if err != nil && !errors.Is(err, fs.ErrNotExist) {
 		return err

--- a/internal/helper/yawollet.go
+++ b/internal/helper/yawollet.go
@@ -892,23 +892,23 @@ func EnableAdHocDebugging(
 	return nil
 }
 
-// ReconcileLatestRevisionFile makes sure that the YawolKeepalivedFile exists if the lbm is from the current revision.
+// ReconcileLatestRevisionFile makes sure that the YawolSetIsLatestRevisionFile exists if the lbm is from the current revision.
 // Otherwise, make sure that the file is deleted.
 // Use aferoFs to use it in tests.
 func ReconcileLatestRevisionFile(filesystem afero.Fs, lb *yawolv1beta1.LoadBalancer, lbm *yawolv1beta1.LoadBalancerMachine) error {
-	if err := filesystem.MkdirAll(YawolKeepalivedDir, 0755); err != nil {
+	if err := filesystem.MkdirAll(YawolLibDir, 0755); err != nil {
 		return err
 	}
 	if lbmIsLatestRevision(lb, lbm) {
 		// file should exist
-		f, err := filesystem.Create(YawolKeepalivedFile)
+		f, err := filesystem.Create(YawolSetIsLatestRevisionFile)
 		if err != nil {
 			return err
 		}
 		return f.Close()
 	}
 	// file should not exist
-	err := filesystem.Remove(YawolKeepalivedFile)
+	err := filesystem.Remove(YawolSetIsLatestRevisionFile)
 	if err != nil && !errors.Is(err, fs.ErrNotExist) {
 		return err
 	}

--- a/internal/helper/yawollet.go
+++ b/internal/helper/yawollet.go
@@ -905,10 +905,11 @@ func ReconcileLatestRevisionFile(filesystem afero.Fs, lb *yawolv1beta1.LoadBalan
 		if err != nil {
 			return err
 		}
+		defer f.Close()
 		if _, err = f.WriteString("1"); err != nil {
 			return err
 		}
-		return f.Close()
+		return nil
 	}
 	// file should not exist
 	err := filesystem.Remove(YawolSetIsLatestRevisionFile)

--- a/internal/helper/yawollet.go
+++ b/internal/helper/yawollet.go
@@ -895,20 +895,20 @@ func EnableAdHocDebugging(
 // ReconcileLatestRevisionFile makes sure that the YawolKeepalivedFile exists if the lbm is from the current revision.
 // Otherwise, make sure that the file is deleted.
 // Use aferoFs to use it in tests.
-func ReconcileLatestRevisionFile(aferoFs afero.Fs, lb *yawolv1beta1.LoadBalancer, lbm *yawolv1beta1.LoadBalancerMachine) error {
-	if err := aferoFs.MkdirAll(YawolKeepalivedDir, 0755); err != nil {
+func ReconcileLatestRevisionFile(filesystem afero.Fs, lb *yawolv1beta1.LoadBalancer, lbm *yawolv1beta1.LoadBalancerMachine) error {
+	if err := filesystem.MkdirAll(YawolKeepalivedDir, 0755); err != nil {
 		return err
 	}
 	if lbmIsLatestRevision(lb, lbm) {
 		// file should exist
-		f, err := aferoFs.Create(YawolKeepalivedFile)
+		f, err := filesystem.Create(YawolKeepalivedFile)
 		if err != nil {
 			return err
 		}
 		return f.Close()
 	}
 	// file should not exist
-	err := aferoFs.Remove(YawolKeepalivedFile)
+	err := filesystem.Remove(YawolKeepalivedFile)
 	if err != nil && !errors.Is(err, fs.ErrNotExist) {
 		return err
 	}

--- a/internal/helper/yawollet.go
+++ b/internal/helper/yawollet.go
@@ -896,6 +896,9 @@ func EnableAdHocDebugging(
 // Otherwise, make sure that the file is deleted.
 // Use aferoFs to use it in tests.
 func ReconcileLatestRevisionFile(aferoFs afero.Fs, lb *yawolv1beta1.LoadBalancer, lbm *yawolv1beta1.LoadBalancerMachine) error {
+	if err := aferoFs.MkdirAll(YawolKeepalivedDir, 0755); err != nil {
+		return err
+	}
 	if lbmIsLatestRevision(lb, lbm) {
 		// file should exist
 		f, err := aferoFs.Create(YawolKeepalivedFile)

--- a/internal/helper/yawollet.go
+++ b/internal/helper/yawollet.go
@@ -905,6 +905,9 @@ func ReconcileLatestRevisionFile(filesystem afero.Fs, lb *yawolv1beta1.LoadBalan
 		if err != nil {
 			return err
 		}
+		if _, err = f.WriteString("1"); err != nil {
+			return err
+		}
 		return f.Close()
 	}
 	// file should not exist


### PR DESCRIPTION
Currently it can take some seconds until the new keepalived is taking over, because the old LoadbalancerMachine gets deleted and we relay on keepalived to quickly taking over.

This consists of multible parts:
- add revision annotation also to loadbalancermachine on creation
- add `ContainsKeepalivedMaster` condition on loadbalancerset to identify if there is a keepalived master in this set
- yawollet is now increase the prio of the keepalived if the loadbalancermachine is from the current revision, so new loadbalancermachines have a higher prio.
- yawol-controller, waits with scaledown of old loadbalancersets until the `ContainsKeepalivedMaster ` condition on the lbs is true for 2 min