### PR TITLE
Improve LeaderElection

### DIFF
--- a/cmd/yawol-cloud-controller/main.go
+++ b/cmd/yawol-cloud-controller/main.go
@@ -121,15 +121,16 @@ func main() {
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
 
 	targetMgr, err := ctrl.NewManager(getConfigFromKubeconfigOrDie(targetKubeconfig), ctrl.Options{
-		Scheme:                     scheme,
-		MetricsBindAddress:         metricsAddr,
-		Port:                       9443,
-		LeaderElection:             targetEnableLeaderElection,
-		LeaderElectionID:           "4c878ae2.stackit.cloud",
-		LeaseDuration:              &leasesDuration,
-		RenewDeadline:              &leasesRenewDeadline,
-		RetryPeriod:                &leasesRetryPeriod,
-		LeaderElectionResourceLock: leasesLeaderElectionResourceLock,
+		Scheme:                        scheme,
+		MetricsBindAddress:            metricsAddr,
+		Port:                          9443,
+		LeaderElection:                targetEnableLeaderElection,
+		LeaderElectionReleaseOnCancel: true,
+		LeaderElectionID:              "4c878ae2.stackit.cloud",
+		LeaseDuration:                 &leasesDuration,
+		RenewDeadline:                 &leasesRenewDeadline,
+		RetryPeriod:                   &leasesRetryPeriod,
+		LeaderElectionResourceLock:    leasesLeaderElectionResourceLock,
 	})
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")
@@ -137,16 +138,17 @@ func main() {
 	}
 
 	controlMgr, err := ctrl.NewManager(getConfigFromKubeconfigOrDie(controlKubeconfig), ctrl.Options{
-		Scheme:                     scheme,
-		MetricsBindAddress:         "0",
-		Port:                       9443,
-		Namespace:                  *infrastructureDefaults.Namespace,
-		LeaderElection:             controlEnableLeaderElection,
-		LeaderElectionID:           "4c878ae2.stackit.cloud",
-		LeaseDuration:              &leasesDuration,
-		RenewDeadline:              &leasesRenewDeadline,
-		RetryPeriod:                &leasesRetryPeriod,
-		LeaderElectionResourceLock: leasesLeaderElectionResourceLock,
+		Scheme:                        scheme,
+		MetricsBindAddress:            "0",
+		Port:                          9443,
+		Namespace:                     *infrastructureDefaults.Namespace,
+		LeaderElection:                controlEnableLeaderElection,
+		LeaderElectionReleaseOnCancel: true,
+		LeaderElectionID:              "4c878ae2.stackit.cloud",
+		LeaseDuration:                 &leasesDuration,
+		RenewDeadline:                 &leasesRenewDeadline,
+		RetryPeriod:                   &leasesRetryPeriod,
+		LeaderElectionResourceLock:    leasesLeaderElectionResourceLock,
 	})
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")

--- a/cmd/yawol-controller/main.go
+++ b/cmd/yawol-controller/main.go
@@ -151,16 +151,17 @@ func main() {
 	// LoadBalancer Controller
 	if lbController {
 		loadBalancerMgr, err = ctrl.NewManager(cfg, ctrl.Options{
-			Scheme:                     scheme,
-			MetricsBindAddress:         metricsAddrLb,
-			Port:                       9443,
-			LeaderElection:             enableLeaderElection,
-			LeaderElectionID:           "3a7ac996.stackit.cloud",
-			LeaseDuration:              &leasesDuration,
-			RenewDeadline:              &leasesRenewDeadline,
-			RetryPeriod:                &leasesRetryPeriod,
-			LeaderElectionResourceLock: leasesLeaderElectionResourceLock,
-			Namespace:                  clusterNamespace,
+			Scheme:                        scheme,
+			MetricsBindAddress:            metricsAddrLb,
+			Port:                          9443,
+			LeaderElection:                enableLeaderElection,
+			LeaderElectionReleaseOnCancel: true,
+			LeaderElectionID:              "3a7ac996.stackit.cloud",
+			LeaseDuration:                 &leasesDuration,
+			RenewDeadline:                 &leasesRenewDeadline,
+			RetryPeriod:                   &leasesRetryPeriod,
+			LeaderElectionResourceLock:    leasesLeaderElectionResourceLock,
+			Namespace:                     clusterNamespace,
 		})
 		if err != nil {
 			setupLog.Error(err, "unable to start manager")
@@ -196,16 +197,17 @@ func main() {
 	// LoadBalancerSet Controller
 	if lbSetController {
 		loadBalancerSetMgr, err = ctrl.NewManager(cfg, ctrl.Options{
-			Scheme:                     scheme,
-			MetricsBindAddress:         metricsAddrLbs,
-			Port:                       9444,
-			LeaderElection:             enableLeaderElection,
-			LeaderElectionID:           "rgp5vg43.stackit.cloud",
-			LeaseDuration:              &leasesDuration,
-			RenewDeadline:              &leasesRenewDeadline,
-			RetryPeriod:                &leasesRetryPeriod,
-			LeaderElectionResourceLock: leasesLeaderElectionResourceLock,
-			Namespace:                  clusterNamespace,
+			Scheme:                        scheme,
+			MetricsBindAddress:            metricsAddrLbs,
+			Port:                          9444,
+			LeaderElection:                enableLeaderElection,
+			LeaderElectionReleaseOnCancel: true,
+			LeaderElectionID:              "rgp5vg43.stackit.cloud",
+			LeaseDuration:                 &leasesDuration,
+			RenewDeadline:                 &leasesRenewDeadline,
+			RetryPeriod:                   &leasesRetryPeriod,
+			LeaderElectionResourceLock:    leasesLeaderElectionResourceLock,
+			Namespace:                     clusterNamespace,
 		})
 		if err != nil {
 			setupLog.Error(err, "unable to start manager")
@@ -246,16 +248,17 @@ func main() {
 		discoveryClient := discovery.NewDiscoveryClientForConfigOrDie(cfg)
 
 		loadBalancerMachineMgr, err = ctrl.NewManager(cfg, ctrl.Options{
-			Scheme:                     scheme,
-			MetricsBindAddress:         metricsAddrLbm,
-			Port:                       9445,
-			LeaderElection:             enableLeaderElection,
-			LeaderElectionID:           "tanf7ges.stackit.cloud",
-			LeaseDuration:              &leasesDuration,
-			RenewDeadline:              &leasesRenewDeadline,
-			RetryPeriod:                &leasesRetryPeriod,
-			LeaderElectionResourceLock: leasesLeaderElectionResourceLock,
-			Namespace:                  clusterNamespace,
+			Scheme:                        scheme,
+			MetricsBindAddress:            metricsAddrLbm,
+			Port:                          9445,
+			LeaderElection:                enableLeaderElection,
+			LeaderElectionReleaseOnCancel: true,
+			LeaderElectionID:              "tanf7ges.stackit.cloud",
+			LeaseDuration:                 &leasesDuration,
+			RenewDeadline:                 &leasesRenewDeadline,
+			RetryPeriod:                   &leasesRetryPeriod,
+			LeaderElectionResourceLock:    leasesLeaderElectionResourceLock,
+			Namespace:                     clusterNamespace,
 		})
 		if err != nil {
 			setupLog.Error(err, "unable to start manager")

--- a/cmd/yawollet/main.go
+++ b/cmd/yawollet/main.go
@@ -57,7 +57,6 @@ func init() {
 func main() {
 	var metricsAddr string
 	var probeAddr string
-	var enableLeaderElection bool
 	var namespace string
 	var loadbalancerName string
 	var loadbalancerMachineName string
@@ -68,9 +67,6 @@ func main() {
 
 	flag.StringVar(&metricsAddr, "metrics-bind-address", "0", "The address the metric endpoint binds to. Default is disabled.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", "0", "The address the probe endpoint binds to. Default is disabled.")
-	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
-		"Enable leader election for controller manager. "+
-			"Enabling this will ensure there is only one active controller manager.")
 
 	flag.StringVar(&namespace, "namespace", "", "The namespace from lb und lbm object.")
 	flag.StringVar(&loadbalancerName, "loadbalancer-name", "", "Name of lb object.")
@@ -192,8 +188,7 @@ func main() {
 		Scheme:             scheme,
 		MetricsBindAddress: metricsAddr,
 		Port:               9443,
-		LeaderElection:     enableLeaderElection,
-		LeaderElectionID:   "9df1d9a0.stackit.cloud",
+		LeaderElection:     false,
 		Namespace:          namespace,
 
 		NewCache: func(config *rest.Config, opts cache.Options) (cache.Cache, error) {


### PR DESCRIPTION
- remove leader election settings from yawollet, it needs to be false to be work so there is no need for a option to enable it
- add `LeaderElectionReleaseOnCancel` to `yawol-controller` and `yawol-cloud-controller`