### PR TITLE
fix bug that the loadbalancermachine which is NOT keepalived master get deleted first

### DIFF
--- a/controllers/yawol-controller/loadbalancerset/loadbalancerset_controller.go
+++ b/controllers/yawol-controller/loadbalancerset/loadbalancerset_controller.go
@@ -230,7 +230,7 @@ func findFirstMachineForDeletion(machines []yawolv1beta1.LoadBalancerMachine) (y
 	for i := range machines {
 		for _, c := range *machines[i].Status.Conditions {
 			if string(c.Type) == string(helper.KeepalivedMaster) &&
-				string(c.Status) != string(helper.ConditionFalse) {
+				string(c.Status) != string(helper.ConditionTrue) {
 				return machines[i], nil
 			}
 		}


### PR DESCRIPTION
Currently the lbm with the keepalived master gets deleted first 🤦🏻‍♂️ 