### PR TITLE
ignore sigs.k8s.io/controller-runtime/tools/setup-envtest in renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -5,5 +5,8 @@
   ],
   "dependencyDashboard": true,
   "postUpdateOptions": ["gomodTidy"],
-  "labels": ["kind/upgrade"]
+  "labels": ["kind/upgrade"],
+  "ignoreDeps": [
+    "sigs.k8s.io/controller-runtime/tools/setup-envtest"
+  ]
 }

--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	k8s.io/client-go v0.27.3
 	k8s.io/utils v0.0.0-20230505201702-9f6742963106
 	sigs.k8s.io/controller-runtime v0.15.0
-	sigs.k8s.io/controller-runtime/tools/setup-envtest v0.0.0-20230523032821-116a1b831fff // v0.15.0
+	sigs.k8s.io/controller-runtime/tools/setup-envtest v0.0.0-20230523032821-116a1b831fff // controller-runtime v0.15.0
 	sigs.k8s.io/controller-tools v0.12.1
 )
 


### PR DESCRIPTION
ignore sigs.k8s.io/controller-runtime/tools/setup-envtest to keep it the same as the controller runtime