### PR TITLE
Add possibility to use multiple loadbalancerClasses and use `service.spec.loadBalancerClass`

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,7 @@ metadata:
     # Reference the name of the SSH key provided to OpenStack for debugging .
     yawol.stackit.cloud/debugsshkey: "OS-keyName"
     # Allows filtering services in cloud-controller.
+    # Deprecated: Use service.spec.loadBalancerClass instead.
     yawol.stackit.cloud/className: "test"
     # Specify the number of LoadBalancer machines to deploy (default 1).
     yawol.stackit.cloud/replicas: "3"

--- a/api/v1beta1/loadbalancer_types.go
+++ b/api/v1beta1/loadbalancer_types.go
@@ -32,6 +32,7 @@ const (
 	// ServiceDebugSSHKey set an sshkey
 	ServiceDebugSSHKey = "yawol.stackit.cloud/debugsshkey"
 	// ServiceClassName for filtering services in cloud-controller
+	// Deprecated: use .spec.loadBalancerClass instead
 	ServiceClassName = "yawol.stackit.cloud/className"
 	// ServiceReplicas for setting loadbalancer replicas in cloud-controller
 	ServiceReplicas = "yawol.stackit.cloud/replicas"

--- a/cmd/yawol-cloud-controller/main.go
+++ b/cmd/yawol-cloud-controller/main.go
@@ -101,8 +101,8 @@ func main() {
 		"K8s credentials for deploying the LoadBalancer resources.")
 	flag.Var(&classNames, "classname",
 		"Only listen to Services with the given className. Can be set multiple times. "+
-			"Always listen to "+helper.DefaultLoadbalancerClass+"."+
-			"See also --empty-classname.")
+			"If no classname is set it will defaults to "+helper.DefaultLoadbalancerClass+" "+
+			"and services without class. See also --empty-classname.")
 	flag.BoolVar(&emptyClassName, "empty-classname", true,
 		"Listen to services without a loadBalancerClass. Default is true.")
 	flag.IntVar(&leasesDurationInt, "leases-duration", 60,
@@ -121,7 +121,9 @@ func main() {
 	opts.BindFlags(flag.CommandLine)
 	flag.Parse()
 
-	classNames = append(classNames, helper.DefaultLoadbalancerClass)
+	if len(classNames) == 0 {
+		classNames = append(classNames, helper.DefaultLoadbalancerClass)
+	}
 	if emptyClassName {
 		classNames = append(classNames, "")
 	}

--- a/controllers/yawol-cloud-controller/targetcontroller/suite_test.go
+++ b/controllers/yawol-cloud-controller/targetcontroller/suite_test.go
@@ -17,6 +17,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	yawolv1beta1 "github.com/stackitcloud/yawol/api/v1beta1"
+	"github.com/stackitcloud/yawol/internal/helper"
 	// +kubebuilder:scaffold:imports
 )
 
@@ -101,7 +102,7 @@ var _ = BeforeSuite(func() {
 		Log:                    ctrl.Log.WithName("controllers").WithName("Service"),
 		Scheme:                 k8sManager.GetScheme(),
 		Recorder:               k8sManager.GetEventRecorderFor("Loadbalancer"),
-		ClassName:              "",
+		ClassNames:             []string{"", helper.DefaultLoadbalancerClass},
 	}).SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -104,7 +104,6 @@ The controllers are using the default kubeconfig ($KUBECONFIG, InCluster or
    # or
    kubectl create deployment --image nginx:latest nginx --replicas 1
    kubectl expose deployment --port 80 --type LoadBalancer nginx --name loadbalancer
-   kubectl annotate service loadbalancer yawol.stackit.cloud/className=test # annotation needs to match the value of the `classname` flag from `run-ycc.sh`
    ```
 
 2. Check if the yawol-cloud-controller created a new `LoadBalancer` object

--- a/example-setup/yawol-cloud-controller/service.yaml
+++ b/example-setup/yawol-cloud-controller/service.yaml
@@ -15,6 +15,7 @@ metadata:
     # yawol.stackit.cloud/tcpProxyProtocol: "false"
     # yawol.stackit.cloud/tcpProxyProtocolPortsFilter: ""
 spec:
+  loadBalancerClass: "test"
   type: LoadBalancer
   selector:
     app: nginx

--- a/internal/helper/const.go
+++ b/internal/helper/const.go
@@ -12,4 +12,5 @@ const (
 	LoadBalancerKind             = "LoadBalancer"
 	VRRPInstanceName             = "ENVOY"
 	HasKeepalivedMaster          = "HasKeepalivedMaster"
+	DefaultLoadbalancerClass     = "stackit.cloud/yawol"
 )

--- a/internal/helper/service.go
+++ b/internal/helper/service.go
@@ -13,6 +13,7 @@ import (
 	coreV1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -165,7 +166,7 @@ func GetLoadBalancerNameFromService(service *coreV1.Service) string {
 }
 
 func getLoadBalancerClass(service *coreV1.Service) string {
-	if className, ok := service.Annotations[yawolv1beta1.ServiceClassName]; ok {
+	if className := service.Annotations[yawolv1beta1.ServiceClassName]; className != "" {
 		return className
 	}
 
@@ -177,14 +178,7 @@ func getLoadBalancerClass(service *coreV1.Service) string {
 }
 
 func CheckLoadBalancerClasses(service *coreV1.Service, validClasses []string) bool {
-	serviceClassName := getLoadBalancerClass(service)
-
-	for _, validClass := range validClasses {
-		if validClass == serviceClassName {
-			return true
-		}
-	}
-	return false
+	return sets.New(validClasses...).Has(getLoadBalancerClass(service))
 }
 
 // ValidateService checks if the service is valid

--- a/internal/helper/service.go
+++ b/internal/helper/service.go
@@ -164,6 +164,29 @@ func GetLoadBalancerNameFromService(service *coreV1.Service) string {
 	return service.Namespace + "--" + service.Name
 }
 
+func getLoadBalancerClass(service *coreV1.Service) string {
+	if className, ok := service.Annotations[yawolv1beta1.ServiceClassName]; ok {
+		return className
+	}
+
+	if service.Spec.LoadBalancerClass != nil {
+		return *service.Spec.LoadBalancerClass
+	}
+
+	return ""
+}
+
+func CheckLoadBalancerClasses(service *coreV1.Service, validClasses []string) bool {
+	serviceClassName := getLoadBalancerClass(service)
+
+	for _, validClass := range validClasses {
+		if validClass == serviceClassName {
+			return true
+		}
+	}
+	return false
+}
+
 // ValidateService checks if the service is valid
 func ValidateService(svc *coreV1.Service) error {
 	for _, port := range svc.Spec.Ports {

--- a/internal/helper/service_test.go
+++ b/internal/helper/service_test.go
@@ -1,0 +1,53 @@
+package helper
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/pointer"
+
+	yawolv1beta1 "github.com/stackitcloud/yawol/api/v1beta1"
+)
+
+var _ = Describe("loadbalancerClasses", Serial, Ordered, func() {
+	svc := corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "default",
+		},
+		Spec: corev1.ServiceSpec{},
+	}
+
+	It("should return correct loadbalancerClass from annotation", func() {
+		s := svc.DeepCopy()
+		s.Annotations = map[string]string{
+			yawolv1beta1.ServiceClassName: "foo",
+		}
+		expected := "foo"
+		Expect(getLoadBalancerClass(s)).To(Equal(expected))
+	})
+
+	It("should return correct loadbalancerClass from spec", func() {
+		s := svc.DeepCopy()
+		s.Spec.LoadBalancerClass = pointer.String("bar")
+		expected := "bar"
+		Expect(getLoadBalancerClass(s)).To(Equal(expected))
+	})
+
+	It("should return correct loadbalancerClass from annotation if also set in spec", func() {
+		s := svc.DeepCopy()
+		s.Annotations = map[string]string{
+			yawolv1beta1.ServiceClassName: "foo",
+		}
+		s.Spec.LoadBalancerClass = pointer.String("bar")
+		expected := "foo"
+		Expect(getLoadBalancerClass(s)).To(Equal(expected))
+	})
+
+	It("should return empty string if no class is set", func() {
+		s := svc.DeepCopy()
+		expected := ""
+		Expect(getLoadBalancerClass(s)).To(Equal(expected))
+	})
+})

--- a/run-ycc.sh
+++ b/run-ycc.sh
@@ -7,4 +7,4 @@
 #export FLAVOR_ID="osAyv1W3z2TU5D6h" # m1.amphora
 #export IMAGE_ID="332c90c3-3141-4413-9ef9-f70a472cedb6" # yawol-alpine-v0.5.0
 
-go run ./cmd/yawol-cloud-controller/main.go --classname test --target-kubeconfig=inClusterConfig --control-kubeconfig=inClusterConfig
+go run ./cmd/yawol-cloud-controller/main.go --classname test --empty-classname=false --target-kubeconfig=inClusterConfig --control-kubeconfig=inClusterConfig


### PR DESCRIPTION
yawol-cloud-controller:
- Use `service.spec.loadBalancerClass`
- Add possibility to add multiple loadBalancerClasses via flags
  - Always add "stackit.cloud/yawol" as default
- Add `--empty-classname` flag to also react on services without a class (default is true)

**Breaking Change** because if a `className` was set in the `yawol-cloud-controller` an empty class would be ignored. To have the same behavior, it is necessary to add `--empty-classname`. Most likely this is only used in dev/debug scenarios.


fix #164 