### PR TITLE
Improve metrics for deletion of objects

### DIFF
--- a/charts/yawol-controller/Chart.yaml
+++ b/charts/yawol-controller/Chart.yaml
@@ -3,5 +3,5 @@ description: Helm chart for yawol-controller
 name: yawol-controller
 sources:
   - https://github.com/stackitcloud/yawol
-version: 0.17.0
-appVersion: v0.17.0
+version: 0.17.1
+appVersion: v0.17.1

--- a/docs/components.md
+++ b/docs/components.md
@@ -105,20 +105,23 @@ OpenStack instance where the yawollet and Envoy do the actual Load Balancing.
 
 The yawol-controller provides some metrics which are exposed via the `/metrics` endpoint.
 
-| metric                             | description                                                                                                                                   | exposed by                                      |
-|------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------|
-| yawol_openstack                    | Openstack usage counter by api, object, operation                                                                                             | loadbalancer and loadbalancermachine controller |
-| loadbalancer_info                  | Loadbalancer Info for LoadBalancer contains labels like isInternal, externalIP, tcpProxyProtocol, tcpIdleTimeout, udpIdleTimeout, lokiEnabled | loadbalancer controller                         |
-| loadbalancer_openstack_info        | Openstack Info contains labels with the OpenStackIDs for LoadBalancer                                                                         | loadbalancer controller                         |
-| loadbalancer_replicas              | Replicas for LoadBalancer (from lb.spec.replicas)                                                                                             | loadbalancer controller                         |
-| loadbalancer_replicas_current      | Current replicas for LoadBalancer (from lb.status.replicas)                                                                                   | loadbalancer controller                         |
-| loadbalancer_replicas_ready        | Ready replicas for LoadBalancer (from lb.status.readyReplicas)                                                                                | loadbalancer controller                         |
-| loadbalancerset_replicas           | Replicas for LoadBalancerSet (from lbs.spec.replicas)                                                                                         | loadbalancerset controller                      |
-| loadbalancerset_replicas_current   | Current replicas for LoadBalancerSet (from lbs.status.replicas)                                                                               | loadbalancerset controller                      |
-| loadbalancerset_replicas_ready     | Ready replicas for LoadBalancerSet (from lbs.status.readyReplicas)                                                                            | loadbalancerset controller                      |
-| loadbalancermachine                | Metrics of loadbalancermachine (all metrics from lbm.status.metrics)                                                                          | loadbalancermachine controller                  |
-| loadbalancermachine_condition      | Conditions of loadbalancermachine (lbm.status.conditions)                                                                                     | loadbalancermachine controller                  |
-| loadbalancermachine_openstack_info | Openstack Info contains labels with the OpenStackIDs for LoadBalancerMachine                                                                  | loadbalancermachine controller                  |
+| metric                                 | description                                                                                                                                   | exposed by                                      |
+|----------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------|
+| yawol_openstack                        | Openstack usage counter by api, object, operation                                                                                             | loadbalancer and loadbalancermachine controller |
+| loadbalancer_info                      | Loadbalancer Info for LoadBalancer contains labels like isInternal, externalIP, tcpProxyProtocol, tcpIdleTimeout, udpIdleTimeout, lokiEnabled | loadbalancer controller                         |
+| loadbalancer_openstack_info            | Openstack Info contains labels with the OpenStackIDs for LoadBalancer                                                                         | loadbalancer controller                         |
+| loadbalancer_replicas                  | Replicas for LoadBalancer (from lb.spec.replicas, 0 if marked for deletion)                                                                   | loadbalancer controller                         |
+| loadbalancer_replicas_current          | Current replicas for LoadBalancer (from lb.status.replicas)                                                                                   | loadbalancer controller                         |
+| loadbalancer_replicas_ready            | Ready replicas for LoadBalancer (from lb.status.readyReplicas)                                                                                | loadbalancer controller                         |
+| loadbalancer_deletion_timestamp        | Deletion timestamp of a LoadBalancer in seconds since epoch (only present for LoadBalancers in deletion)                                      | loadbalancer controller                         |
+| loadbalancerset_replicas               | Replicas for LoadBalancerSet (from lbs.spec.replicas, 0 if marked for deletion)                                                               | loadbalancerset controller                      |
+| loadbalancerset_replicas_current       | Current replicas for LoadBalancerSet (from lbs.status.replicas)                                                                               | loadbalancerset controller                      |
+| loadbalancerset_replicas_ready         | Ready replicas for LoadBalancerSet (from lbs.status.readyReplicas)                                                                            | loadbalancerset controller                      |
+| loadbalancerset_deletion_timestamp     | Deletion timestamp of a LoadBalancerSet in seconds since epoch (only present for LoadBalancerSets in deletion)                                | loadbalancerset controller                      |
+| loadbalancermachine                    | Metrics of loadbalancermachine (all metrics from lbm.status.metrics)                                                                          | loadbalancermachine controller                  |
+| loadbalancermachine_condition          | Conditions of loadbalancermachine (lbm.status.conditions)                                                                                     | loadbalancermachine controller                  |
+| loadbalancermachine_openstack_info     | Openstack Info contains labels with the OpenStackIDs for LoadBalancerMachine                                                                  | loadbalancermachine controller                  |
+| loadbalancermachine_deletion_timestamp | Deletion timestamp of a LoadBalancerMachine in seconds since epoch (only present for LoadBalancerMachines in deletion)                        | loadbalancermachine controller                  |
 
 ## yawollet
 

--- a/internal/helper/loadbalancer.go
+++ b/internal/helper/loadbalancer.go
@@ -320,6 +320,7 @@ func ParseLoadBalancerMetrics(
 	parseLoadBalancerInfoMetric(lb, metrics.InfoMetrics)
 	parseLoadBalancerOpenstackMetric(lb, metrics.OpenstackInfoMetrics)
 	parseLoadBalancerReadyMetric(lb, metrics.ReplicasMetrics, metrics.ReplicasCurrentMetrics, metrics.ReplicasReadyMetrics)
+	parseLoadBalancerDeletionTimestampMetric(lb, metrics.DeletionTimestampMetrics)
 }
 
 func parseLoadBalancerInfoMetric(
@@ -421,6 +422,19 @@ func parseLoadBalancerReadyMetric(
 	}
 }
 
+func parseLoadBalancerDeletionTimestampMetric(
+	lb yawolv1beta1.LoadBalancer,
+	loadBalancerDeletionTimestampMetrics *prometheus.GaugeVec,
+) {
+	if loadBalancerDeletionTimestampMetrics == nil {
+		return
+	}
+
+	if lb.DeletionTimestamp != nil {
+		loadBalancerDeletionTimestampMetrics.WithLabelValues(lb.Name, lb.Namespace).Set(float64(lb.DeletionTimestamp.Unix()))
+	}
+}
+
 func RemoveLoadBalancerMetrics(
 	lb yawolv1beta1.LoadBalancer,
 	metrics *helpermetrics.LoadBalancerMetricList,
@@ -430,7 +444,8 @@ func RemoveLoadBalancerMetrics(
 		metrics.OpenstackInfoMetrics == nil ||
 		metrics.ReplicasMetrics == nil ||
 		metrics.ReplicasCurrentMetrics == nil ||
-		metrics.ReplicasReadyMetrics == nil {
+		metrics.ReplicasReadyMetrics == nil ||
+		metrics.DeletionTimestampMetrics == nil {
 		return
 	}
 	l := map[string]string{
@@ -442,4 +457,5 @@ func RemoveLoadBalancerMetrics(
 	metrics.ReplicasMetrics.DeletePartialMatch(l)
 	metrics.ReplicasCurrentMetrics.DeletePartialMatch(l)
 	metrics.ReplicasReadyMetrics.DeletePartialMatch(l)
+	metrics.DeletionTimestampMetrics.DeletePartialMatch(l)
 }

--- a/internal/helper/loadbalancerset.go
+++ b/internal/helper/loadbalancerset.go
@@ -204,9 +204,16 @@ func ParseLoadBalancerSetMetrics(
 		return
 	}
 
+	specReplicas := lbs.Spec.Replicas
+	if lbs.DeletionTimestamp != nil {
+		// If deletionTimestamp is set, the desired state is to have 0 replicas. Setting this metrics to 0 makes it easier
+		// to define alerts that should not trigger false positives, if a LoadBalancer takes a long time to delete.
+		specReplicas = 0
+	}
 	metrics.ReplicasMetrics.
 		WithLabelValues(lbs.Spec.Template.Spec.LoadBalancerRef.Name, lbs.Name, lbs.Namespace).
-		Set(float64(lbs.Spec.Replicas))
+		Set(float64(specReplicas))
+
 	if lbs.Status.Replicas != nil {
 		metrics.ReplicasCurrentMetrics.
 			WithLabelValues(lbs.Spec.Template.Spec.LoadBalancerRef.Name, lbs.Name, lbs.Namespace).

--- a/internal/helper/loadbalancerset.go
+++ b/internal/helper/loadbalancerset.go
@@ -200,7 +200,8 @@ func ParseLoadBalancerSetMetrics(
 	if metrics == nil ||
 		metrics.ReplicasMetrics == nil ||
 		metrics.ReplicasCurrentMetrics == nil ||
-		metrics.ReplicasReadyMetrics == nil {
+		metrics.ReplicasReadyMetrics == nil ||
+		metrics.DeletionTimestampMetrics == nil {
 		return
 	}
 
@@ -224,6 +225,12 @@ func ParseLoadBalancerSetMetrics(
 			WithLabelValues(lbs.Spec.Template.Spec.LoadBalancerRef.Name, lbs.Name, lbs.Namespace).
 			Set(float64(*lbs.Status.ReadyReplicas))
 	}
+
+	if lbs.DeletionTimestamp != nil {
+		metrics.DeletionTimestampMetrics.
+			WithLabelValues(lbs.Spec.Template.Spec.LoadBalancerRef.Name, lbs.Name, lbs.Namespace).
+			Set(float64(lbs.DeletionTimestamp.Unix()))
+	}
 }
 
 func RemoveLoadBalancerSetMetrics(
@@ -233,7 +240,8 @@ func RemoveLoadBalancerSetMetrics(
 	if metrics == nil ||
 		metrics.ReplicasMetrics == nil ||
 		metrics.ReplicasCurrentMetrics == nil ||
-		metrics.ReplicasReadyMetrics == nil {
+		metrics.ReplicasReadyMetrics == nil ||
+		metrics.DeletionTimestampMetrics == nil {
 		return
 	}
 
@@ -245,4 +253,5 @@ func RemoveLoadBalancerSetMetrics(
 	metrics.ReplicasMetrics.DeletePartialMatch(l)
 	metrics.ReplicasCurrentMetrics.DeletePartialMatch(l)
 	metrics.ReplicasReadyMetrics.DeletePartialMatch(l)
+	metrics.DeletionTimestampMetrics.DeletePartialMatch(l)
 }

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -111,7 +111,7 @@ var (
 	// LoadBalancerSetDeletionTimestampMetrics Deletion timestamp of a LoadBalancerSet in seconds since epoch
 	LoadBalancerSetDeletionTimestampMetrics = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "loadbalancerset_deletion_timestamp",
-		Help: "Deletion timestamp of a LoadBalancerSet in seconds since epoch (only present for LoadBalancers in deletion)",
+		Help: "Deletion timestamp of a LoadBalancerSet in seconds since epoch (only present for LoadBalancerSets in deletion)",
 	}, []string{"lb", "lbs", "namespace"})
 
 	// LoadBalancerMachineVMMetrics Metrics of loadbalancermachine (all metrics from lbm.status.metrics)
@@ -132,7 +132,7 @@ var (
 	// LoadBalancerMachineDeletionTimestampMetrics Deletion timestamp of a LoadBalancerMachine in seconds since epoch
 	LoadBalancerMachineDeletionTimestampMetrics = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "loadbalancermachine_deletion_timestamp",
-		Help: "Deletion timestamp of a LoadBalancerMachine in seconds since epoch (only present for LoadBalancers in deletion)",
+		Help: "Deletion timestamp of a LoadBalancerMachine in seconds since epoch (only present for LoadBalancerMachines in deletion)",
 	}, []string{"lb", "lbm", "namespace"})
 )
 

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -69,7 +69,7 @@ var (
 	// LoadBalancerReplicasMetrics Replicas for LoadBalancer (from lb.spec.replicas)
 	LoadBalancerReplicasMetrics = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "loadbalancer_replicas",
-		Help: "Replicas for LoadBalancer (from lb.spec.replicas)",
+		Help: "Replicas for LoadBalancer (from lb.spec.replicas, 0 if marked for deletion)",
 	}, []string{"lb", "namespace"})
 	// LoadBalancerReplicasCurrentMetrics Current replicas for LoadBalancer (from lb.status.replicas)
 	LoadBalancerReplicasCurrentMetrics = prometheus.NewGaugeVec(prometheus.GaugeOpts{
@@ -85,7 +85,7 @@ var (
 	// LoadBalancerSetReplicasMetrics Replicas for LoadBalancerSet (from lbs.spec.replicas)
 	LoadBalancerSetReplicasMetrics = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "loadbalancerset_replicas",
-		Help: "Replicas for LoadBalancerSet (from lbs.spec.replicas)",
+		Help: "Replicas for LoadBalancerSet (from lbs.spec.replicas, 0 if marked for deletion)",
 	}, []string{"lb", "lbs", "namespace"})
 	// LoadBalancerSetReplicasCurrentMetrics Current replicas for LoadBalancerSet (from lbs.status.replicas)
 	LoadBalancerSetReplicasCurrentMetrics = prometheus.NewGaugeVec(prometheus.GaugeOpts{

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -6,47 +6,53 @@ import (
 )
 
 type LoadBalancerMetricList struct {
-	OpenstackMetrics       *prometheus.CounterVec
-	InfoMetrics            *prometheus.GaugeVec
-	OpenstackInfoMetrics   *prometheus.GaugeVec
-	ReplicasMetrics        *prometheus.GaugeVec
-	ReplicasCurrentMetrics *prometheus.GaugeVec
-	ReplicasReadyMetrics   *prometheus.GaugeVec
+	OpenstackMetrics         *prometheus.CounterVec
+	InfoMetrics              *prometheus.GaugeVec
+	OpenstackInfoMetrics     *prometheus.GaugeVec
+	ReplicasMetrics          *prometheus.GaugeVec
+	ReplicasCurrentMetrics   *prometheus.GaugeVec
+	ReplicasReadyMetrics     *prometheus.GaugeVec
+	DeletionTimestampMetrics *prometheus.GaugeVec
 }
 
 var LoadBalancerMetrics = LoadBalancerMetricList{
-	OpenstackMetrics:       OpenstackMetrics,
-	InfoMetrics:            LoadBalancerInfoMetrics,
-	OpenstackInfoMetrics:   LoadBalancerOpenstackInfoMetrics,
-	ReplicasMetrics:        LoadBalancerReplicasMetrics,
-	ReplicasCurrentMetrics: LoadBalancerReplicasCurrentMetrics,
-	ReplicasReadyMetrics:   LoadBalancerReplicasReadyMetrics,
+	OpenstackMetrics:         OpenstackMetrics,
+	InfoMetrics:              LoadBalancerInfoMetrics,
+	OpenstackInfoMetrics:     LoadBalancerOpenstackInfoMetrics,
+	ReplicasMetrics:          LoadBalancerReplicasMetrics,
+	ReplicasCurrentMetrics:   LoadBalancerReplicasCurrentMetrics,
+	ReplicasReadyMetrics:     LoadBalancerReplicasReadyMetrics,
+	DeletionTimestampMetrics: LoadBalancerDeletionTimestampMetrics,
 }
 
 type LoadBalancerSetMetricList struct {
-	ReplicasMetrics        *prometheus.GaugeVec
-	ReplicasCurrentMetrics *prometheus.GaugeVec
-	ReplicasReadyMetrics   *prometheus.GaugeVec
+	ReplicasMetrics          *prometheus.GaugeVec
+	ReplicasCurrentMetrics   *prometheus.GaugeVec
+	ReplicasReadyMetrics     *prometheus.GaugeVec
+	DeletionTimestampMetrics *prometheus.GaugeVec
 }
 
 var LoadBalancerSetMetrics = LoadBalancerSetMetricList{
-	ReplicasMetrics:        LoadBalancerSetReplicasMetrics,
-	ReplicasCurrentMetrics: LoadBalancerSetReplicasCurrentMetrics,
-	ReplicasReadyMetrics:   LoadBalancerSetReplicasReadyMetrics,
+	ReplicasMetrics:          LoadBalancerSetReplicasMetrics,
+	ReplicasCurrentMetrics:   LoadBalancerSetReplicasCurrentMetrics,
+	ReplicasReadyMetrics:     LoadBalancerSetReplicasReadyMetrics,
+	DeletionTimestampMetrics: LoadBalancerSetDeletionTimestampMetrics,
 }
 
 type LoadBalancerMachineMetricList struct {
-	VM                   *prometheus.GaugeVec
-	Conditions           *prometheus.GaugeVec
-	OpenstackMetrics     *prometheus.CounterVec
-	OpenstackInfoMetrics *prometheus.GaugeVec
+	VM                       *prometheus.GaugeVec
+	Conditions               *prometheus.GaugeVec
+	OpenstackMetrics         *prometheus.CounterVec
+	OpenstackInfoMetrics     *prometheus.GaugeVec
+	DeletionTimestampMetrics *prometheus.GaugeVec
 }
 
 var LoadBalancerMachineMetrics = LoadBalancerMachineMetricList{
-	VM:                   LoadBalancerMachineVMMetrics,
-	Conditions:           LoadBalancerMachineConditionMetrics,
-	OpenstackMetrics:     OpenstackMetrics,
-	OpenstackInfoMetrics: LoadBalancerMachineOpenstackInfoMetrics,
+	VM:                       LoadBalancerMachineVMMetrics,
+	Conditions:               LoadBalancerMachineConditionMetrics,
+	OpenstackMetrics:         OpenstackMetrics,
+	OpenstackInfoMetrics:     LoadBalancerMachineOpenstackInfoMetrics,
+	DeletionTimestampMetrics: LoadBalancerMachineDeletionTimestampMetrics,
 }
 
 var (
@@ -81,6 +87,11 @@ var (
 		Name: "loadbalancer_replicas_ready",
 		Help: "Ready replicas for LoadBalancer (from lb.status.readyReplicas)",
 	}, []string{"lb", "namespace"})
+	// LoadBalancerDeletionTimestampMetrics Deletion timestamp of a LoadBalancer in seconds since epoch
+	LoadBalancerDeletionTimestampMetrics = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "loadbalancer_deletion_timestamp",
+		Help: "Deletion timestamp of a LoadBalancer in seconds since epoch (only present for LoadBalancers in deletion)",
+	}, []string{"lb", "namespace"})
 
 	// LoadBalancerSetReplicasMetrics Replicas for LoadBalancerSet (from lbs.spec.replicas)
 	LoadBalancerSetReplicasMetrics = prometheus.NewGaugeVec(prometheus.GaugeOpts{
@@ -96,6 +107,11 @@ var (
 	LoadBalancerSetReplicasReadyMetrics = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "loadbalancerset_replicas_ready",
 		Help: "Ready replicas for LoadBalancerSet (from lbs.status.readyReplicas)",
+	}, []string{"lb", "lbs", "namespace"})
+	// LoadBalancerSetDeletionTimestampMetrics Deletion timestamp of a LoadBalancerSet in seconds since epoch
+	LoadBalancerSetDeletionTimestampMetrics = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "loadbalancerset_deletion_timestamp",
+		Help: "Deletion timestamp of a LoadBalancerSet in seconds since epoch (only present for LoadBalancers in deletion)",
 	}, []string{"lb", "lbs", "namespace"})
 
 	// LoadBalancerMachineVMMetrics Metrics of loadbalancermachine (all metrics from lbm.status.metrics)
@@ -113,6 +129,11 @@ var (
 		Name: "loadbalancermachine_openstack_info",
 		Help: "Openstack Info contains labels with the OpenStackIDs for LoadBalancerMachine",
 	}, []string{"lb", "lbm", "namespace", "portID", "serverID", "flavorID"})
+	// LoadBalancerMachineDeletionTimestampMetrics Deletion timestamp of a LoadBalancerMachine in seconds since epoch
+	LoadBalancerMachineDeletionTimestampMetrics = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "loadbalancermachine_deletion_timestamp",
+		Help: "Deletion timestamp of a LoadBalancerMachine in seconds since epoch (only present for LoadBalancers in deletion)",
+	}, []string{"lb", "lbm", "namespace"})
 )
 
 func init() {
@@ -123,10 +144,13 @@ func init() {
 	metrics.Registry.MustRegister(LoadBalancerReplicasMetrics)
 	metrics.Registry.MustRegister(LoadBalancerReplicasCurrentMetrics)
 	metrics.Registry.MustRegister(LoadBalancerReplicasReadyMetrics)
+	metrics.Registry.MustRegister(LoadBalancerDeletionTimestampMetrics)
 	metrics.Registry.MustRegister(LoadBalancerSetReplicasMetrics)
 	metrics.Registry.MustRegister(LoadBalancerSetReplicasCurrentMetrics)
 	metrics.Registry.MustRegister(LoadBalancerSetReplicasReadyMetrics)
+	metrics.Registry.MustRegister(LoadBalancerSetDeletionTimestampMetrics)
 	metrics.Registry.MustRegister(LoadBalancerMachineVMMetrics)
 	metrics.Registry.MustRegister(LoadBalancerMachineConditionMetrics)
 	metrics.Registry.MustRegister(LoadBalancerMachineOpenstackInfoMetrics)
+	metrics.Registry.MustRegister(LoadBalancerMachineDeletionTimestampMetrics)
 }


### PR DESCRIPTION
During deletion our alerts are sometimes triggering false positives. Also, we can't build a proper alert for LoadBalancers stuck in deletion. 

This is fixed in this PR by
- setting `*_replicas` to `0` for objects in deletion
- adding `*_deletion_timestamp` metrics similar to what kube-state-metrics is doing for [pods](https://github.com/kubernetes/kube-state-metrics/blob/v2.9.2/internal/store/pod.go#L575-L598)