### PR TITLE
feat(chart): add custom service labels and annotations to helm-chart for yawol-controller and yawol-cloud-controller

### DIFF
--- a/charts/yawol-controller/Chart.yaml
+++ b/charts/yawol-controller/Chart.yaml
@@ -3,5 +3,5 @@ description: Helm chart for yawol-controller
 name: yawol-controller
 sources:
   - https://github.com/stackitcloud/yawol
-version: 0.17.1
-appVersion: v0.17.1
+version: 0.17.2
+appVersion: v0.17.2

--- a/charts/yawol-controller/templates/yawol-gardener-monitoring.yaml
+++ b/charts/yawol-controller/templates/yawol-gardener-monitoring.yaml
@@ -33,7 +33,12 @@ kind: Service
 metadata:
   name: yawol-cloud-controller
   namespace: {{ .Release.Namespace }}
+  annotations:
+    {{- toYaml .Values.yawolCloudController.service.annotations | nindent 4 }}
   labels:
+    {{- with .Values.yawolCloudController.service.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
     app: kubernetes
     role: yawol-cloud-controller
 spec:
@@ -118,7 +123,12 @@ kind: Service
 metadata:
   name: yawol-controller
   namespace: {{ .Release.Namespace }}
+  annotations:
+    {{- toYaml .Values.yawolController.service.annotations | nindent 4 }}
   labels:
+    {{- with .Values.yawolController.service.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
     app: kubernetes
     role: yawol-controller
 spec:

--- a/charts/yawol-controller/values.yaml
+++ b/charts/yawol-controller/values.yaml
@@ -4,6 +4,7 @@ podLabels: {}
 featureGates: {}
 proxy: {}
 namespace: kube-system
+
 vpa:
   enabled: false
   yawolCloudController:
@@ -15,6 +16,9 @@ yawolCloudController:
   enabled: true
   gardenerMonitoringEnabled: false
   clusterRoleEnabled: true
+  service:
+    annotations: {}
+    labels: {}
   image:
     repository: ghcr.io/stackitcloud/yawol/yawol-cloud-controller
     # -- Allows you to override the yawol version in this chart. Use at your own risk.
@@ -24,6 +28,9 @@ yawolController:
   gardenerMonitoringEnabled: false
   errorBackoffBaseDelay: 5ms
   errorBackoffMaxDelay: 1000s
+  service:
+    annotations: {}
+    labels: {}
   image:
     repository: ghcr.io/stackitcloud/yawol/yawol-controller
     # -- Allows you to override the yawol version in this chart. Use at your own risk.


### PR DESCRIPTION
This PR includes the ability to add custom labels and annotations to both `yawol-controller` and `yawol-cloud-controller` services.