### PR TITLE
improve cloud init timeouts

### DIFF
--- a/image/cloud-init-10_openstack.cfg
+++ b/image/cloud-init-10_openstack.cfg
@@ -1,3 +1,4 @@
+datasource_list: ["OpenStack"]
 datasource:
   OpenStack:
 #    metadata_urls: ["http://169.254.169.254"]

--- a/image/cloud-init-initd
+++ b/image/cloud-init-initd
@@ -1,0 +1,14 @@
+#!/sbin/openrc-run
+# add depends for network, dns, fs etc
+depend() {
+  after cloud-init-local
+  after net
+  before cloud-config
+  provide cloud-init
+  keyword -timeout
+}
+
+start() {
+  cloud-init init
+  eend 0
+}

--- a/image/cloud-init.config
+++ b/image/cloud-init.config
@@ -1,0 +1,7 @@
+datasource:
+  OpenStack:
+#    metadata_urls: ["http://169.254.169.254"]
+#    max_wait: -1
+    timeout: 10
+    retries: 5
+#    apply_network_config: True

--- a/image/cloud-init.config
+++ b/image/cloud-init.config
@@ -2,6 +2,6 @@ datasource:
   OpenStack:
 #    metadata_urls: ["http://169.254.169.254"]
 #    max_wait: -1
-    timeout: 10
-    retries: 5
+    timeout: 15
+    retries: 10
 #    apply_network_config: True

--- a/image/install-alpine.yaml
+++ b/image/install-alpine.yaml
@@ -239,6 +239,14 @@
     - name: enable keepalivedstats
       command: "rc-update add keepalivedstats default"
 
+    - name: add cloud-init config
+      copy:
+        src: ./cloud-init.config
+        dest: /etc/cloud/cloud.cfg.d/10_openstack.cfg
+        owner: root
+        group: root
+        mode: 0644
+
     - name: enable cloud-config
       command: "rc-update add cloud-config default"
     - name: enable cloud-init-local

--- a/image/install-alpine.yaml
+++ b/image/install-alpine.yaml
@@ -241,7 +241,7 @@
 
     - name: add cloud-init config
       copy:
-        src: ./cloud-init.config
+        src: ./cloud-init-10_openstack.cfg
         dest: /etc/cloud/cloud.cfg.d/10_openstack.cfg
         owner: root
         group: root
@@ -254,6 +254,12 @@
         owner: root
         group: root
         mode: 0755
+
+    - name: disable resizefs in cloud-init
+      ansible.builtin.lineinfile:
+        path: /etc/cloud/cloud.cfg
+        regexp: '^(#)?\s- resizefs.*'
+        line: '# - resizefs'
 
     - name: enable cloud-config
       command: "rc-update add cloud-config default"

--- a/image/install-alpine.yaml
+++ b/image/install-alpine.yaml
@@ -247,6 +247,14 @@
         group: root
         mode: 0644
 
+    - name: overwrite cloud-init initd file
+      copy:
+        src: ./cloud-init-initd
+        dest: /etc/init.d/cloud-init
+        owner: root
+        group: root
+        mode: 0755
+
     - name: enable cloud-config
       command: "rc-update add cloud-config default"
     - name: enable cloud-init-local


### PR DESCRIPTION
In some cases the `cloud-init` fails because it get not all data from openstack in time. 

- This affacts all services they depend on `cloud-init`, so we add the `keyword -timeout` to the openrc file from `cloud-init`
- Increase timeouts for OpenStack datasource in cloud-init

Also the `resizefs` step of `cloud-init` failed because there is no `resize2fs` on the system so we disabled this step.
