### PR TITLE
Set `Metrics.BindAddress` to 0 to disable metrics server for control-controller

### DIFF
--- a/cmd/yawol-cloud-controller/main.go
+++ b/cmd/yawol-cloud-controller/main.go
@@ -162,6 +162,9 @@ func main() {
 				*infrastructureDefaults.Namespace: {},
 			},
 		},
+		Metrics: server.Options{
+			BindAddress: "0",
+		},
 		LeaderElection:                controlEnableLeaderElection,
 		LeaderElectionReleaseOnCancel: true,
 		LeaderElectionID:              "4c878ae2.stackit.cloud",


### PR DESCRIPTION
If the `Metrics.BindAddress` is not explicitly set to `0`, the controller manger starts a metrics server on the default port (`8080`), which causes the yawol-cloud-controller to crash:

```
"error": "failed to start metrics server: failed to create listener: listen tcp :8080: bind: address already in use"}
```

This PR reintroduces the setting to disable the metrics server completely. This was inadvertently removed in #241 and made it to `main` (and the latest release) undetected.