### PR TITLE
Fix(secgroups): ICMP Echo Request being blocked

### DIFF
--- a/controllers/yawol-controller/loadbalancer/loadbalancer_controller_test.go
+++ b/controllers/yawol-controller/loadbalancer/loadbalancer_controller_test.go
@@ -905,8 +905,8 @@ func getDesiredSecGroups(remoteID string) []rules.SecGroupRule {
 				EtherType:    string(etherType),
 				Direction:    string(rules.DirIngress),
 				Protocol:     string(rules.ProtocolICMP),
-				PortRangeMin: 1,
-				PortRangeMax: 8,
+				PortRangeMin: 8,
+				PortRangeMax: 0,
 			},
 		)
 	}

--- a/internal/helper/loadbalancer.go
+++ b/internal/helper/loadbalancer.go
@@ -218,8 +218,8 @@ func GetDesiredSecGroupRulesForLoadBalancer(r record.EventRecorder, lb *yawolv1b
 				EtherType:    string(etherType),
 				Direction:    string(rules.DirIngress),
 				Protocol:     string(icmpProtocol),
-				PortRangeMin: 1,
-				PortRangeMax: 8,
+				PortRangeMin: 8, // icmp_type
+				PortRangeMax: 0, // icmp_code
 			})
 	}
 


### PR DESCRIPTION
This fixes a thing that never worked before 😄 

Currently ICMP echo requests are blocked by the ingress security group rules for ICMP, which looks like this: `type=1:code=8` (ICMP type 1 is not used for anything in the ICMP protocol).

After this PR the ingress security group rules will look like this: `type=8` (`code` seems to be omitted by openstack if it is `0`) and allows ICMP echo requests to reach the VM.

Egress isn't a problem because the egress security group rule doesn't block anything.