### PR TITLE
Allow overriding of creation timeout for `LoadBalancerMachines`

### DIFF
--- a/api/v1beta1/loadbalancermachine_types.go
+++ b/api/v1beta1/loadbalancermachine_types.go
@@ -5,6 +5,13 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+const (
+	// LoadBalancerMachineCreationTimeoutAnnotation can be set on a LoadBalancerMachine to override
+	// the default duration of 10 minutes, after which a new LoadBalancerMachine
+	// is deleted (by the LBM) if it reports no conditions yet.
+	LoadBalancerMachineCreationTimeoutAnnotation = "yawol.stackit.cloud/creationTimeout"
+)
+
 // +kubebuilder:object:root=true
 // +kubebuilder:resource:shortName=lbm
 // +kubebuilder:subresource:status

--- a/api/v1beta1/loadbalancerset_types.go
+++ b/api/v1beta1/loadbalancerset_types.go
@@ -4,13 +4,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-const (
-	// CreationTimeoutAnnotation can be set to override the defaut duration of
-	// 10 minutes, after which a new LoadBalancerMachine is deleted (by the LBM)
-	// if it reports no conditions yet.
-	CreationTimeoutAnnotation = "yawol.stackit.cloud/creationTimeout"
-)
-
 // +kubebuilder:object:root=true
 // +kubebuilder:resource:shortName=lbs
 // +kubebuilder:subresource:status

--- a/api/v1beta1/loadbalancerset_types.go
+++ b/api/v1beta1/loadbalancerset_types.go
@@ -4,6 +4,13 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+const (
+	// CreationTimeoutAnnotation can be set to override the defaut duration of
+	// 10 minutes, after which a new LoadBalancerMachine is deleted (by the LBM)
+	// if it reports no conditions yet.
+	CreationTimeoutAnnotation = "yawol.stackit.cloud/creationTimeout"
+)
+
 // +kubebuilder:object:root=true
 // +kubebuilder:resource:shortName=lbs
 // +kubebuilder:subresource:status

--- a/controllers/yawol-controller/loadbalancerset/loadbalancerset_controller.go
+++ b/controllers/yawol-controller/loadbalancerset/loadbalancerset_controller.go
@@ -249,7 +249,7 @@ func shouldMachineBeDeleted(machine *yawolv1beta1.LoadBalancerMachine) (shouldDe
 	before3Minutes := metav1.Time{Time: time.Now().Add(-3 * time.Minute)}
 
 	creationTimeoutDuration := 10 * time.Minute
-	if v := machine.Annotations[yawolv1beta1.CreationTimeoutAnnotation]; v != "" {
+	if v := machine.Annotations[yawolv1beta1.LoadBalancerMachineCreationTimeoutAnnotation]; v != "" {
 		// silently ignore errors
 		if parsed, err := time.ParseDuration(v); err == nil {
 			creationTimeoutDuration = parsed

--- a/controllers/yawol-controller/loadbalancerset/loadbalancerset_controller_test.go
+++ b/controllers/yawol-controller/loadbalancerset/loadbalancerset_controller_test.go
@@ -382,7 +382,29 @@ func TestIsMachineReady(t *testing.T) {
 func TestShouldMachineBeDeleted(t *testing.T) {
 	t.Run("Do not delete if there are no conditions shortly after creation", func(t *testing.T) {
 		machine := &yawolv1beta1.LoadBalancerMachine{
-			ObjectMeta: metav1.ObjectMeta{CreationTimestamp: metav1.Time{Time: time.Now().Add(-9 * time.Minute)}},
+			ObjectMeta: metav1.ObjectMeta{
+				CreationTimestamp: metav1.Time{Time: time.Now().Add(-9 * time.Minute)},
+			},
+			Status: yawolv1beta1.LoadBalancerMachineStatus{
+				Conditions: nil,
+			},
+		}
+		got, _ := shouldMachineBeDeleted(machine)
+		want := false
+
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("Expected %v got %v", want, got)
+		}
+	})
+
+	t.Run("Do not delete if there are no conditions and the grace period has been adjusted", func(t *testing.T) {
+		machine := &yawolv1beta1.LoadBalancerMachine{
+			ObjectMeta: metav1.ObjectMeta{
+				CreationTimestamp: metav1.Time{Time: time.Now().Add(-30 * time.Minute)},
+				Annotations: map[string]string{
+					yawolv1beta1.CreationTimeoutAnnotation: "1h",
+				},
+			},
 			Status: yawolv1beta1.LoadBalancerMachineStatus{
 				Conditions: nil,
 			},

--- a/controllers/yawol-controller/loadbalancerset/loadbalancerset_controller_test.go
+++ b/controllers/yawol-controller/loadbalancerset/loadbalancerset_controller_test.go
@@ -402,7 +402,7 @@ func TestShouldMachineBeDeleted(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				CreationTimestamp: metav1.Time{Time: time.Now().Add(-30 * time.Minute)},
 				Annotations: map[string]string{
-					yawolv1beta1.CreationTimeoutAnnotation: "1h",
+					yawolv1beta1.LoadBalancerMachineCreationTimeoutAnnotation: "1h",
 				},
 			},
 			Status: yawolv1beta1.LoadBalancerMachineStatus{
@@ -411,6 +411,26 @@ func TestShouldMachineBeDeleted(t *testing.T) {
 		}
 		got, _ := shouldMachineBeDeleted(machine)
 		want := false
+
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("Expected %v got %v", want, got)
+		}
+	})
+
+	t.Run("Delete if there are no conditions after a custom grace period", func(t *testing.T) {
+		machine := &yawolv1beta1.LoadBalancerMachine{
+			ObjectMeta: metav1.ObjectMeta{
+				CreationTimestamp: metav1.Time{Time: time.Now().Add(-30 * time.Minute)},
+				Annotations: map[string]string{
+					yawolv1beta1.LoadBalancerMachineCreationTimeoutAnnotation: "15m",
+				},
+			},
+			Status: yawolv1beta1.LoadBalancerMachineStatus{
+				Conditions: nil,
+			},
+		}
+		got, _ := shouldMachineBeDeleted(machine)
+		want := true
 
 		if !reflect.DeepEqual(got, want) {
 			t.Errorf("Expected %v got %v", want, got)


### PR DESCRIPTION
The LoadbalancerSet controller (specifically the LBM status controller) currently deletes any LBM that takes more than 10 Minutes to report their first condition. This change allows users to override this duration per object by setting the annotation `yawol.stackit.cloud/creationTimeout` on `LoadBalancerMachine` objects.