### PR TITLE
Add imageID to`loadbalancermachine_openstack_info` Metric

### DIFF
--- a/internal/helper/loadbalancermachine.go
+++ b/internal/helper/loadbalancermachine.go
@@ -130,10 +130,14 @@ func parseLoadBalancerMachineOpenstackInfoMetrics(
 		"portID":    "nil",
 		"serverID":  "nil",
 		"flavorID":  "nil",
+		"imageID":   "nil",
 	}
 
 	if loadBalancerMachine.Spec.Infrastructure.Flavor.FlavorID != nil {
 		labels["flavorID"] = *loadBalancerMachine.Spec.Infrastructure.Flavor.FlavorID
+	}
+	if loadBalancerMachine.Spec.Infrastructure.Image.ImageID != nil {
+		labels["imageID"] = *loadBalancerMachine.Spec.Infrastructure.Image.ImageID
 	}
 
 	if loadBalancerMachine.Status.DefaultPortID != nil {

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -128,7 +128,7 @@ var (
 	LoadBalancerMachineOpenstackInfoMetrics = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "loadbalancermachine_openstack_info",
 		Help: "Openstack Info contains labels with the OpenStackIDs for LoadBalancerMachine",
-	}, []string{"lb", "lbm", "namespace", "portID", "serverID", "flavorID"})
+	}, []string{"lb", "lbm", "namespace", "portID", "serverID", "flavorID", "imageID"})
 	// LoadBalancerMachineDeletionTimestampMetrics Deletion timestamp of a LoadBalancerMachine in seconds since epoch
 	LoadBalancerMachineDeletionTimestampMetrics = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "loadbalancermachine_deletion_timestamp",


### PR DESCRIPTION
We are already tracking e.g. `flavorID` per LBM, but not imageID. Tracking imageID is useful to watch a rollout. Since this does not change the cardinality of the metric this change should have no impact.