### PR TITLE
Add possibility to release floating ip, port and security groups

### DIFF
--- a/api/v1beta1/loadbalancer_types.go
+++ b/api/v1beta1/loadbalancer_types.go
@@ -69,15 +69,15 @@ const (
 	// If logForward is enabled, annotations that are prefixed with this constant
 	// will be used as extra labels for loki
 	LoadBalancerLogLabelPrefix = "logging.yawol.stackit.cloud/"
-	// KeepFloatingIPAnnotation indicates the controller to not delete the floating ip on lb deletion.
+	// LoadBalancerKeepFloatingIP indicates the controller to not delete the floating ip on lb deletion.
 	// When set to 'true' deleting the annotated loadbalancer will orphan the floating ip.
-	KeepFloatingIPAnnotation = "yawol.stackit.cloud/keepFloatingIP"
-	// KeepPortAnnotation indicates the controller to not delete the port on lb deletion.
+	LoadBalancerKeepFloatingIP = "yawol.stackit.cloud/keepFloatingIP"
+	// LoadBalancerKeepPort indicates the controller to not delete the port on lb deletion.
 	// When set to 'true' deleting the annotated loadbalancer will orphan the port.
-	KeepPortAnnotation = "yawol.stackit.cloud/keepPort"
-	// KeepSecurityGroupAnnotation indicates the controller to not delete the security group on lb deletion.
+	LoadBalancerKeepPort = "yawol.stackit.cloud/keepPort"
+	// LoadBalancerKeepSecurityGroup indicates the controller to not delete the security group on lb deletion.
 	// When set to 'true' deleting the annotated loadbalancer will orphan the security group.
-	KeepSecurityGroupAnnotation = "yawol.stackit.cloud/keepSecurityGroup"
+	LoadBalancerKeepSecurityGroup = "yawol.stackit.cloud/keepSecurityGroup"
 )
 
 // +kubebuilder:object:root=true

--- a/api/v1beta1/loadbalancer_types.go
+++ b/api/v1beta1/loadbalancer_types.go
@@ -69,6 +69,15 @@ const (
 	// If logForward is enabled, annotations that are prefixed with this constant
 	// will be used as extra labels for loki
 	LoadBalancerLogLabelPrefix = "logging.yawol.stackit.cloud/"
+	// KeepFloatingIPAnnotation indicates the controller to not delete the floating ip on lb deletion.
+	// When set to 'true' deleting the annotated loadbalancer will orphan the floating ip.
+	KeepFloatingIPAnnotation = "yawol.stackit.cloud/keepFloatingIP"
+	// KeepPortAnnotation indicates the controller to not delete the port on lb deletion.
+	// When set to 'true' deleting the annotated loadbalancer will orphan the port.
+	KeepPortAnnotation = "yawol.stackit.cloud/keepPort"
+	// KeepSecurityGroupAnnotation indicates the controller to not delete the security group on lb deletion.
+	// When set to 'true' deleting the annotated loadbalancer will orphan the security group.
+	KeepSecurityGroupAnnotation = "yawol.stackit.cloud/keepSecurityGroup"
 )
 
 // +kubebuilder:object:root=true

--- a/controllers/yawol-controller/loadbalancer/loadbalancer_controller.go
+++ b/controllers/yawol-controller/loadbalancer/loadbalancer_controller.go
@@ -1118,7 +1118,7 @@ func (r *Reconciler) deleteFips(
 	var requeue = false
 
 	// skip deletion and release status when annotated
-	if lb.GetAnnotations()[KeepFloatingIPAnnotation] == "true" {
+	if lb.GetAnnotations()[yawolv1beta1.LoadBalancerKeepFloatingIP] == "true" {
 		if lb.Status.FloatingID == nil &&
 			lb.Status.FloatingName == nil {
 			return false, nil
@@ -1243,7 +1243,7 @@ func (r *Reconciler) deletePorts(
 	}
 
 	// skip deletion and release status when annotated
-	if lb.GetAnnotations()[KeepPortAnnotation] == "true" {
+	if lb.GetAnnotations()[yawolv1beta1.LoadBalancerKeepPort] == "true" {
 		if lb.Status.PortID == nil {
 			return false, nil
 		}
@@ -1345,7 +1345,7 @@ func (r *Reconciler) deleteSecGroups(
 		return false, err
 	}
 	// skip deletion and release status when annotated
-	if lb.GetAnnotations()[KeepSecurityGroupAnnotation] == "true" {
+	if lb.GetAnnotations()[yawolv1beta1.LoadBalancerKeepSecurityGroup] == "true" {
 		if lb.Status.SecurityGroupID == nil {
 			return false, nil
 		}

--- a/controllers/yawol-controller/loadbalancer/loadbalancer_controller.go
+++ b/controllers/yawol-controller/loadbalancer/loadbalancer_controller.go
@@ -1121,7 +1121,7 @@ func (r *Reconciler) deleteFips(
 	var requeue = false
 
 	// skip deletion and release status when annotated
-	if lb.GetLabels()[KeepFloatingIPAnnotation] == "true" {
+	if lb.GetAnnotations()[KeepFloatingIPAnnotation] == "true" {
 		if lb.Status.FloatingID == nil &&
 			lb.Status.FloatingName == nil {
 			return false, nil
@@ -1246,7 +1246,7 @@ func (r *Reconciler) deletePorts(
 	}
 
 	// skip deletion and release status when annotated
-	if lb.GetLabels()[KeepPortAnnotation] == "true" {
+	if lb.GetAnnotations()[KeepPortAnnotation] == "true" {
 		if lb.Status.PortID == nil {
 			return false, nil
 		}
@@ -1348,7 +1348,7 @@ func (r *Reconciler) deleteSecGroups(
 		return false, err
 	}
 	// skip deletion and release status when annotated
-	if lb.GetLabels()[KeepSecurityGroupAnnotation] == "true" {
+	if lb.GetAnnotations()[KeepSecurityGroupAnnotation] == "true" {
 		if lb.Status.SecurityGroupID == nil {
 			return false, nil
 		}

--- a/controllers/yawol-controller/loadbalancer/loadbalancer_controller.go
+++ b/controllers/yawol-controller/loadbalancer/loadbalancer_controller.go
@@ -37,11 +37,8 @@ import (
 )
 
 const (
-	DefaultRequeueTime          = 10 * time.Millisecond
-	ServiceFinalizer            = "yawol.stackit.cloud/controller2"
-	KeepFloatingIPAnnotation    = "yawol.stackit.cloud/keepFloatingIP"
-	KeepPortAnnotation          = "yawol.stackit.cloud/keepPort"
-	KeepSecurityGroupAnnotation = "yawol.stackit.cloud/keepSecurityGroup"
+	DefaultRequeueTime = 10 * time.Millisecond
+	ServiceFinalizer   = "yawol.stackit.cloud/controller2"
 )
 
 // LoadBalancerReconciler reconciles service Objects with type LoadBalancer

--- a/controllers/yawol-controller/loadbalancer/loadbalancer_controller.go
+++ b/controllers/yawol-controller/loadbalancer/loadbalancer_controller.go
@@ -2,6 +2,7 @@ package loadbalancer
 
 import (
 	"context"
+	"strconv"
 	"time"
 
 	"github.com/stackitcloud/yawol/internal/helper"
@@ -1118,7 +1119,7 @@ func (r *Reconciler) deleteFips(
 	var requeue = false
 
 	// skip deletion and release status when annotated
-	if lb.GetAnnotations()[yawolv1beta1.LoadBalancerKeepFloatingIP] == "true" {
+	if keep, err := strconv.ParseBool(lb.GetAnnotations()[yawolv1beta1.LoadBalancerKeepFloatingIP]); err == nil && keep {
 		if lb.Status.FloatingID == nil &&
 			lb.Status.FloatingName == nil {
 			return false, nil
@@ -1243,7 +1244,7 @@ func (r *Reconciler) deletePorts(
 	}
 
 	// skip deletion and release status when annotated
-	if lb.GetAnnotations()[yawolv1beta1.LoadBalancerKeepPort] == "true" {
+	if keep, err := strconv.ParseBool(lb.GetAnnotations()[yawolv1beta1.LoadBalancerKeepPort]); err == nil && keep {
 		if lb.Status.PortID == nil {
 			return false, nil
 		}
@@ -1345,7 +1346,7 @@ func (r *Reconciler) deleteSecGroups(
 		return false, err
 	}
 	// skip deletion and release status when annotated
-	if lb.GetAnnotations()[yawolv1beta1.LoadBalancerKeepSecurityGroup] == "true" {
+	if keep, err := strconv.ParseBool(lb.GetAnnotations()[yawolv1beta1.LoadBalancerKeepSecurityGroup]); err == nil && keep {
 		if lb.Status.SecurityGroupID == nil {
 			return false, nil
 		}

--- a/controllers/yawol-controller/loadbalancer/loadbalancer_controller_test.go
+++ b/controllers/yawol-controller/loadbalancer/loadbalancer_controller_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/ports"
 
 	yawolv1beta1 "github.com/stackitcloud/yawol/api/v1beta1"
-	"github.com/stackitcloud/yawol/controllers/yawol-cloud-controller/targetcontroller"
 	"github.com/stackitcloud/yawol/internal/helper"
 	"github.com/stackitcloud/yawol/internal/openstack"
 	"github.com/stackitcloud/yawol/internal/openstack/testing"
@@ -783,7 +782,7 @@ var _ = Describe("loadbalancer controller", Serial, Ordered, func() {
 					Namespace: namespace,
 				}
 				annotatedLB := getMockLB(nn)
-				annotatedLB.Labels = map[string]string{
+				annotatedLB.Annotations = map[string]string{
 					KeepFloatingIPAnnotation:    "true",
 					KeepPortAnnotation:          "true",
 					KeepSecurityGroupAnnotation: "true",

--- a/controllers/yawol-controller/loadbalancer/loadbalancer_controller_test.go
+++ b/controllers/yawol-controller/loadbalancer/loadbalancer_controller_test.go
@@ -783,9 +783,9 @@ var _ = Describe("loadbalancer controller", Serial, Ordered, func() {
 				}
 				annotatedLB := getMockLB(nn)
 				annotatedLB.Annotations = map[string]string{
-					KeepFloatingIPAnnotation:    "true",
-					KeepPortAnnotation:          "true",
-					KeepSecurityGroupAnnotation: "true",
+					yawolv1beta1.LoadBalancerKeepFloatingIP:    "true",
+					yawolv1beta1.LoadBalancerKeepPort:          "true",
+					yawolv1beta1.LoadBalancerKeepSecurityGroup: "true",
 				}
 				k8sClient.Create(ctx, annotatedLB)
 			})


### PR DESCRIPTION
This PR adds optional annotations to LB objects in order to release 

- floating ip
- port 
- security groups

after deleting a loadbalancer. This enables the possibility to seamlessly move loadbalancer implementations.