### PR TITLE
chart: ycc: add additionalEnv and imagePullSecrets

### DIFF
--- a/charts/yawol-controller/templates/sa-yawol-cloud-controller.yaml
+++ b/charts/yawol-controller/templates/sa-yawol-cloud-controller.yaml
@@ -3,3 +3,7 @@ kind: ServiceAccount
 metadata:
   name: yawol-cloud-controller
   namespace: {{ .Values.namespace }}
+{{- if hasKey .Values.yawolCloudController.serviceAccount "imagePullSecret" }}
+imagePullSecrets:
+  - name: {{ .Values.yawolCloudController.serviceAccount.imagePullSecret }}
+{{- end -}}

--- a/charts/yawol-controller/templates/yawol-cloud-controller.yaml
+++ b/charts/yawol-controller/templates/yawol-cloud-controller.yaml
@@ -73,6 +73,10 @@ spec:
         - name: AVAILABILITY_ZONE
           value: {{ .Values.yawolAvailabilityZone }}
         {{- end }}
+        {{- range $key, $val := .Values.yawolCloudController.additionalEnv }}
+        - name: {{ $key }}
+          value: {{ $val | quote }}
+        {{- end }}
         {{- if .Values.resources.yawolCloudController }}
         resources:
 {{ toYaml .Values.resources.yawolCloudController | indent 10 }}

--- a/charts/yawol-controller/values.yaml
+++ b/charts/yawol-controller/values.yaml
@@ -19,10 +19,14 @@ yawolCloudController:
   service:
     annotations: {}
     labels: {}
+  additionalEnv: {}
+    #ENV_VAR: value
   image:
     repository: ghcr.io/stackitcloud/yawol/yawol-cloud-controller
     # -- Allows you to override the yawol version in this chart. Use at your own risk.
     tag: ""
+  serviceAccount: {}
+    #imagePullSecret: "registry-credentials"
 
 yawolController:
   gardenerMonitoringEnabled: false


### PR DESCRIPTION
This PR adds the possibility to pass additional environment variables to the yawol cloud controller, as well as supplying imagePullSecrets to it's service account, in order to use images from private repositories.