### PR TITLE
bump chart version to `0.21.3-1`

### DIFF
--- a/charts/yawol-controller/Chart.yaml
+++ b/charts/yawol-controller/Chart.yaml
@@ -3,5 +3,5 @@ description: Helm chart for yawol-controller
 name: yawol-controller
 sources:
   - https://github.com/stackitcloud/yawol
-version: "0.21.3"
+version: "0.21.3-1"
 appVersion: v0.21.3


### PR DESCRIPTION
Bump the chart version to `0.21.3-1`, to make chart release workflow happy.