### PR TITLE
Add snyk ignore due to a false positive in client-go

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -2,6 +2,10 @@
 version: v1.22.1
 # ignores vulnerabilities until expiry date; change duration by modifying expiry date
 ignore:
+  'SNYK-GOLANG-K8SIOCLIENTGOTRANSPORT-7538822':
+    - '*':
+        reason: Is fixed in client-go since 2019, due to the new versions of k8s this triggers a false positive
+        created: 2024-07-24T08:16:00.00Z
   SNYK-CC-K8S-48:
     - '*':
         reason: K8s Controller runs in kube-system namespace


### PR DESCRIPTION
This issue [SNYK-GOLANG-K8SIOCLIENTGOTRANSPORT-7538822](https://security.snyk.io/vuln/SNYK-GOLANG-K8SIOCLIENTGOTRANSPORT-7538822) is solved in version [ `1.17.0-alpha.1`](https://github.com/kubernetes/client-go/releases/tag/kubernetes-1.17.0-alpha.1). Due to new tags since `1.17.x` starting with `0.x.y` this triggers a false positive.