### PR TITLE
Fix logforwarding feature

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -5,7 +5,6 @@ ARG BINPATH=/usr/local/bin/
 ARG GOCACHE=/go-cache
 
 ARG ENVOY_VERSION=v1.27.0
-ARG PROMTAIL_VERSION=2.9.0
 ARG HELM_VERSION=3.12.3
 ARG GOLANGCI_LINT_VERSION=v1.54.2
 ARG PACKER_VERSION=1.9
@@ -70,11 +69,6 @@ get-envoy-libs-local:
     COPY +get-envoy/envoylibs /envoylibs
     SAVE ARTIFACT /envoylibs AS LOCAL out/envoy/lib
 
-get-promtail-local:
-    FROM +promtail
-    COPY +promtail/promtail /promtail
-    SAVE ARTIFACT /promtail AS LOCAL out/promtail
-
 get-envoy:
     FROM +envoy
     SAVE ARTIFACT /usr/local/bin/envoy
@@ -131,7 +125,6 @@ build-yawollet-image:
     ARG --required OS_USERNAME
     ARG --required OS_REGION_NAME
 
-    COPY +promtail/promtail out/promtail
     COPY +get-envoy/envoy out/envoy/envoy
     COPY +get-envoy/envoylibs out/envoy/lib
     COPY (+build/controller --CONTROLLER=yawollet --GOOS=$USEROS --GOARCH=$USERARCH) out/yawollet
@@ -354,10 +347,6 @@ terraform:
 envoy:
     FROM envoyproxy/envoy:$ENVOY_VERSION
     SAVE ARTIFACT /usr/local/bin/envoy
-
-promtail:
-    FROM grafana/promtail:$PROMTAIL_VERSION
-    SAVE ARTIFACT /usr/bin/promtail
 
 snyk-linux:
     FROM snyk/snyk:linux

--- a/image/install-alpine.yaml
+++ b/image/install-alpine.yaml
@@ -171,6 +171,9 @@
     - name: install libcap-getcap
       command: "apk add libcap-getcap"
 
+    - name: install libcap-setcap
+      command: "apk add libcap-setcap"
+
     - name: add cap_net_bind_service for envoy
       capabilities:
         path: /usr/local/bin/envoy

--- a/image/install-alpine.yaml
+++ b/image/install-alpine.yaml
@@ -168,6 +168,9 @@
         group: root
         mode: 0755
 
+    - name: install libcap-getcap
+      command: "apk add libcap-getcap"
+
     - name: add cap_net_bind_service for envoy
       capabilities:
         path: /usr/local/bin/envoy

--- a/image/install-alpine.yaml
+++ b/image/install-alpine.yaml
@@ -324,11 +324,17 @@
     - name: disable ssh service
       command: "rc-update del sshd"
 
-    - name: cleanup
+    - name: cleanup apk cache
       command: "rm -rf /var/cache/apk/*"
 
-    - name: more cleanup
+    - name: cleanup cloud-init
       command: "cloud-init clean -l -s"
+
+    - name: cleanup messages
+      lineinfile:
+        path: /var/log/messages
+        state: absent
+        regexp: '.*'
 
     - name: cleanup ssh-keys
       lineinfile:

--- a/image/install-alpine.yaml
+++ b/image/install-alpine.yaml
@@ -201,34 +201,37 @@
         mode: 0755
 
     # promtail
-    - name: upload promtail
-      copy:
-        src: ../out/promtail
-        dest: /usr/local/bin/promtail
-        owner: root
-        group: root
-        mode: 0755
+    - name: install promtail
+      command: "apk add loki-promtail"
 
-    - name: Creating promtail user
-      user:
-        name: "promtail"
-        shell: /bin/ash
-        groups: wheel
-        append: true
+    #- name: upload promtail
+    #  copy:
+    #    src: ../out/promtail
+    #    dest: /usr/local/bin/promtail
+    #    owner: root
+    #    group: root
+    #    mode: 0755
 
-    - name: Create a directory for promtail
-      file:
-        path: /etc/promtail
-        state: directory
-        mode: '0755'
+    #- name: Creating promtail user
+    #  user:
+    #    name: "promtail"
+    #    shell: /bin/ash
+    #    groups: wheel
+    #    append: true
 
-    - name: add openrc promtail
-      copy:
-        src: ./promtail.sh
-        dest: /etc/init.d/promtail
-        owner: root
-        group: root
-        mode: 0755
+    #- name: Create a directory for promtail
+    #  file:
+    #    path: /etc/promtail
+    #    state: directory
+    #    mode: '0755'
+
+    #- name: add openrc promtail
+    #  copy:
+    #    src: ./promtail.sh
+    #    dest: /etc/init.d/promtail
+    #    owner: root
+    #    group: root
+    #    mode: 0755
 
     # reload openrc
     - name: Reload openrc

--- a/image/install-alpine.yaml
+++ b/image/install-alpine.yaml
@@ -210,34 +210,26 @@
     - name: install promtail
       command: "apk add loki-promtail"
 
-    #- name: upload promtail
-    #  copy:
-    #    src: ../out/promtail
-    #    dest: /usr/local/bin/promtail
-    #    owner: root
-    #    group: root
-    #    mode: 0755
+    - name: Creating promtail user
+      user:
+        name: "promtail"
+        shell: /bin/ash
+        groups: wheel
+        append: true
 
-    #- name: Creating promtail user
-    #  user:
-    #    name: "promtail"
-    #    shell: /bin/ash
-    #    groups: wheel
-    #    append: true
+    - name: Create a directory for promtail
+      file:
+        path: /etc/promtail
+        state: directory
+        mode: '0755'
 
-    #- name: Create a directory for promtail
-    #  file:
-    #    path: /etc/promtail
-    #    state: directory
-    #    mode: '0755'
-
-    #- name: add openrc promtail
-    #  copy:
-    #    src: ./promtail.sh
-    #    dest: /etc/init.d/promtail
-    #    owner: root
-    #    group: root
-    #    mode: 0755
+    - name: add openrc promtail
+      copy:
+        src: ./promtail.sh
+        dest: /etc/init.d/promtail
+        owner: root
+        group: root
+        mode: 0755
 
     # reload openrc
     - name: Reload openrc

--- a/image/promtail.sh
+++ b/image/promtail.sh
@@ -2,7 +2,7 @@
 
 name=$RC_SVCNAME
 description="promtail"
-command="/usr/local/bin/promtail"
+command="/usr/bin/promtail"
 command_args="-config.file=/etc/promtail/promtail.yaml"
 command_user="promtail"
 command_background="yes"


### PR DESCRIPTION
The logforwarding with promtail was broken.
Promtail crashed with the following error:
```
:~$ promtail -config.file=/etc/promtail/promtail.yaml
promtail: error while loading shared libraries: libresolv.so.2: cannot open shared object file: No such file or directory
```

Since alpine 3.18 there is also a package [`loki-promtail`](https://pkgs.alpinelinux.org/package/v3.20/community/aarch64/loki-promtail) which includes all dependencies. This PR uses the `loki-promtail` package. 

This PR was tested with alpine 3.20 as base-image based on [alpine-openstack-image](https://github.com/stackitcloud/alpine-openstack-image/tree/0eecac4c40833b164a1e68ef977a9fb42ce3a77b)