### PR TITLE
Add `isNodeTerminating` to node predicate

### DIFF
--- a/controllers/yawol-cloud-controller/targetcontroller/node_controller.go
+++ b/controllers/yawol-cloud-controller/targetcontroller/node_controller.go
@@ -115,6 +115,10 @@ func yawolNodePredicate() predicate.Predicate {
 				return true
 			}
 
+			if isNodeTerminating(*oldNode) != isNodeTerminating(*newNode) {
+				return true
+			}
+
 			return !reflect.DeepEqual(
 				getLoadBalancerEndpointFromNode(*oldNode, []coreV1.IPFamily{}),
 				getLoadBalancerEndpointFromNode(*newNode, []coreV1.IPFamily{}),


### PR DESCRIPTION
The predicate currently will not reconcile if a node is in terminating, which was added in #341 

This PR adds the missing check.