### PR TITLE
helm: allow configuration of zap flags via helm values

### DIFF
--- a/charts/yawol-controller/Chart.yaml
+++ b/charts/yawol-controller/Chart.yaml
@@ -3,5 +3,5 @@ description: Helm chart for yawol-controller
 name: yawol-controller
 sources:
   - https://github.com/stackitcloud/yawol
-version: "0.23.1"
+version: "0.23.1-1"
 appVersion: v0.23.1

--- a/charts/yawol-controller/README.md
+++ b/charts/yawol-controller/README.md
@@ -1,6 +1,6 @@
 # yawol-controller
 
-![Version: 0.12.0](https://img.shields.io/badge/Version-0.12.0-informational?style=flat-square) ![AppVersion: v0.12.0](https://img.shields.io/badge/AppVersion-v0.12.0-informational?style=flat-square)
+![Version: 0.23.1-1](https://img.shields.io/badge/Version-0.23.1--1-informational?style=flat-square) ![AppVersion: v0.23.1](https://img.shields.io/badge/AppVersion-v0.23.1-informational?style=flat-square)
 
 Helm chart for yawol-controller
 
@@ -13,6 +13,10 @@ Helm chart for yawol-controller
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | featureGates | object | `{}` |  |
+| logging | object | `{"encoding":"console","level":"info","stacktraceLevel":"error"}` | values are passed as zap-flags to the containers. See https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.18.4/pkg/log/zap#Options.BindFlags for more information |
+| logging.encoding | string | `"console"` | log encoding (one of 'json' or 'console') |
+| logging.level | string | `"info"` | log-level to omit. Can be one of 'debug', 'info', 'error' or any integer value > 0 which corresponds to custom debug levels of increasing verbosity |
+| logging.stacktraceLevel | string | `"error"` | level at and above which stacktraces are captured (one of 'info', 'error' or 'panic') |
 | namespace | string | `"kube-system"` |  |
 | podAnnotations | object | `{}` |  |
 | podLabels | object | `{}` |  |
@@ -39,18 +43,26 @@ Helm chart for yawol-controller
 | vpa.yawolController.mode | string | `"Auto"` |  |
 | yawolAPIHost | string | `nil` |  |
 | yawolAvailabilityZone | string | `""` |  |
+| yawolCloudController.additionalEnv | object | `{}` |  |
 | yawolCloudController.clusterRoleEnabled | bool | `true` |  |
 | yawolCloudController.enabled | bool | `true` |  |
 | yawolCloudController.gardenerMonitoringEnabled | bool | `false` |  |
 | yawolCloudController.image.repository | string | `"ghcr.io/stackitcloud/yawol/yawol-cloud-controller"` |  |
 | yawolCloudController.image.tag | string | `""` | Allows you to override the yawol version in this chart. Use at your own risk. |
+| yawolCloudController.service.annotations | object | `{}` |  |
+| yawolCloudController.service.labels | object | `{}` |  |
+| yawolCloudController.serviceAccount | object | `{}` |  |
+| yawolController.errorBackoffBaseDelay | string | `"5ms"` |  |
+| yawolController.errorBackoffMaxDelay | string | `"1000s"` |  |
 | yawolController.gardenerMonitoringEnabled | bool | `false` |  |
 | yawolController.image.repository | string | `"ghcr.io/stackitcloud/yawol/yawol-controller"` |  |
 | yawolController.image.tag | string | `""` | Allows you to override the yawol version in this chart. Use at your own risk. |
+| yawolController.service.annotations | object | `{}` |  |
+| yawolController.service.labels | object | `{}` |  |
 | yawolFlavorID | string | `nil` |  |
 | yawolFloatingID | string | `nil` |  |
 | yawolImageID | string | `nil` |  |
 | yawolNetworkID | string | `nil` |  |
-| yawolSubnetID | string | `nil` |  |
 | yawolOSSecretName | string | `nil` |  |
+| yawolSubnetID | string | `nil` |  |
 

--- a/charts/yawol-controller/README.md
+++ b/charts/yawol-controller/README.md
@@ -15,7 +15,7 @@ Helm chart for yawol-controller
 | featureGates | object | `{}` |  |
 | logging | object | `{"encoding":"console","level":"info","stacktraceLevel":"error"}` | values are passed as zap-flags to the containers. See https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.18.4/pkg/log/zap#Options.BindFlags for more information |
 | logging.encoding | string | `"console"` | log encoding (one of 'json' or 'console') |
-| logging.level | string | `"info"` | log-level to omit. Can be one of 'debug', 'info', 'error' or any integer value > 0 which corresponds to custom debug levels of increasing verbosity |
+| logging.level | string | `"info"` | Level to configure the verbosity of logging. Can be one of 'debug', 'info', 'error' or any integer value > 0 which corresponds to custom debug levels of increasing verbosity |
 | logging.stacktraceLevel | string | `"error"` | level at and above which stacktraces are captured (one of 'info', 'error' or 'panic') |
 | namespace | string | `"kube-system"` |  |
 | podAnnotations | object | `{}` |  |

--- a/charts/yawol-controller/templates/_helpers.tpl
+++ b/charts/yawol-controller/templates/_helpers.tpl
@@ -1,3 +1,9 @@
 {{- define "deploymentversion" -}}
 apps/v1
 {{- end -}}
+
+{{- define "logFlags" }}
+- -zap-stacktrace-level={{ .Values.logging.stacktraceLevel }}
+- -zap-log-level={{ .Values.logging.level }}
+- -zap-encoder={{ .Values.logging.encoding }}
+{{- end }}

--- a/charts/yawol-controller/templates/yawol-cloud-controller.yaml
+++ b/charts/yawol-controller/templates/yawol-cloud-controller.yaml
@@ -44,6 +44,7 @@ spec:
         {{- if .Values.yawolClassName }}
         - -classname={{ .Values.yawolClassName }}
         {{- end }}
+        {{- include "logFlags" . | indent 10 }}
         env:
         {{- if .Values.namespace }}
         - name: CLUSTER_NAMESPACE

--- a/charts/yawol-controller/templates/yawol-controller.yaml
+++ b/charts/yawol-controller/templates/yawol-controller.yaml
@@ -46,6 +46,7 @@ spec:
           {{- if .Values.yawolController.errorBackoffMaxDelay }}
           - -error-backoff-max-delay={{ .Values.yawolController.errorBackoffMaxDelay }}
           {{- end }}
+          {{- include "logFlags" . | indent 10 }}
         env:
         {{- if .Values.namespace }}
         - name: CLUSTER_NAMESPACE
@@ -76,6 +77,7 @@ spec:
           {{- if .Values.yawolController.errorBackoffMaxDelay }}
           - -error-backoff-max-delay={{ .Values.yawolController.errorBackoffMaxDelay }}
           {{- end }}
+          {{- include "logFlags" . | indent 10 }}
         env:
           {{- if .Values.namespace }}
           - name: CLUSTER_NAMESPACE
@@ -112,6 +114,7 @@ spec:
           {{- if .Values.yawolController.errorBackoffMaxDelay }}
           - -error-backoff-max-delay={{ .Values.yawolController.errorBackoffMaxDelay }}
           {{- end }}
+          {{- include "logFlags" . | indent 10 }}
         env:
           {{- if .Values.namespace }}
           - name: CLUSTER_NAMESPACE

--- a/charts/yawol-controller/values.yaml
+++ b/charts/yawol-controller/values.yaml
@@ -28,9 +28,13 @@ yawolCloudController:
   serviceAccount: {}
     #imagePullSecret: "registry-credentials"
 
+# -- values are passed as zap-flags to the containers. See https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.18.4/pkg/log/zap#Options.BindFlags for more information
 logging:
+  # -- log-level to omit. Can be one of 'debug', 'info', 'error' or any integer value > 0 which corresponds to custom debug levels of increasing verbosity
   level: info
+  # -- log encoding (one of 'json' or 'console')
   encoding: console
+  # -- level at and above which stacktraces are captured (one of 'info', 'error' or 'panic')
   stacktraceLevel: error
 
 

--- a/charts/yawol-controller/values.yaml
+++ b/charts/yawol-controller/values.yaml
@@ -28,6 +28,12 @@ yawolCloudController:
   serviceAccount: {}
     #imagePullSecret: "registry-credentials"
 
+logging:
+  level: info
+  encoding: console
+  stacktraceLevel: error
+
+
 yawolController:
   gardenerMonitoringEnabled: false
   errorBackoffBaseDelay: 5ms

--- a/charts/yawol-controller/values.yaml
+++ b/charts/yawol-controller/values.yaml
@@ -30,7 +30,7 @@ yawolCloudController:
 
 # -- values are passed as zap-flags to the containers. See https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.18.4/pkg/log/zap#Options.BindFlags for more information
 logging:
-  # -- log-level to omit. Can be one of 'debug', 'info', 'error' or any integer value > 0 which corresponds to custom debug levels of increasing verbosity
+  # -- Level to configure the verbosity of logging. Can be one of 'debug', 'info', 'error' or any integer value > 0 which corresponds to custom debug levels of increasing verbosity
   level: info
   # -- log encoding (one of 'json' or 'console')
   encoding: console


### PR DESCRIPTION
# Motivation
Currently there is no way to configure the logging config of the yawol controllers.
This PR adds support to pass this configuration via helm values.

# New helm values
| Key | Type | Default | Description |
|-----|------|---------|-------------|
| logging | object | `{"encoding":"console","level":"info","stacktraceLevel":"error"}` | values are passed as zap-flags to the containers. See https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.18.4/pkg/log/zap#Options.BindFlags for more information |
| logging.encoding | string | `"console"` | log encoding (one of 'json' or 'console') |
| logging.level | string | `"info"` |Level to configure the verbosity of logging. Can be one of 'debug', 'info', 'error' or any integer value > 0 which corresponds to custom debug levels of increasing verbosity |
| logging.stacktraceLevel | string | `"error"` | level at and above which stacktraces are captured (one of 'info', 'error' or 'panic') |