### PR TITLE
allow yawol to work with self-signed OpenStack APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,8 @@ stringData:
     username="<OS_USERNAME>"
     password="<OS_PASSWORD>"
     region="<OS_REGION_NAME>"
+    # Optional self-signed CA for OpenStack APIs
+    ca-file="/etc/ssl/myca.crt"
 ```
 
 Assuming you saved the secret as `secret-cloud-provider-config.yaml`, apply it with:

--- a/charts/yawol-controller/templates/yawol-cloud-controller.yaml
+++ b/charts/yawol-controller/templates/yawol-cloud-controller.yaml
@@ -44,7 +44,7 @@ spec:
         {{- if .Values.yawolClassName }}
         - -classname={{ .Values.yawolClassName }}
         {{- end }}
-        {{- include "logFlags" . | indent 10 }}
+        {{- include "logFlags" . | indent 8 }}
         env:
         {{- if .Values.namespace }}
         - name: CLUSTER_NAMESPACE

--- a/charts/yawol-controller/templates/yawol-controller.yaml
+++ b/charts/yawol-controller/templates/yawol-controller.yaml
@@ -62,6 +62,10 @@ spec:
           capabilities:
             drop:
               - ALL
+{{- if .Values.yawolController.additionalVolumeMounts }}
+        volumeMounts:
+{{ toYaml .Values.yawolController.additionalVolumeMounts | indent 8 }}
+{{- end }}
       - name: yawol-controller-loadbalancerset
         image: "{{ .Values.yawolController.image.repository }}:{{ default .Chart.AppVersion .Values.yawolController.image.tag }}"
         imagePullPolicy: Always
@@ -93,6 +97,10 @@ spec:
           capabilities:
             drop:
               - ALL
+{{- if .Values.yawolController.additionalVolumeMounts }}
+        volumeMounts:
+{{ toYaml .Values.yawolController.additionalVolumeMounts | indent 8 }}
+{{- end }}
       - name: yawol-controller-loadbalancermachine
         image: "{{ .Values.yawolController.image.repository }}:{{ default .Chart.AppVersion .Values.yawolController.image.tag }}"
         imagePullPolicy: Always
@@ -134,4 +142,12 @@ spec:
           capabilities:
             drop:
               - ALL
+{{- if .Values.yawolController.additionalVolumeMounts }}
+        volumeMounts:
+{{ toYaml .Values.yawolController.additionalVolumeMounts | indent 8 }}
+{{- end }}
       restartPolicy: Always
+{{- if .Values.yawolController.additionalVolumes }}
+      volumes:
+{{ toYaml .Values.yawolController.additionalVolumes | indent 6 }}
+{{- end }}

--- a/charts/yawol-controller/values.yaml
+++ b/charts/yawol-controller/values.yaml
@@ -27,6 +27,8 @@ yawolCloudController:
     tag: ""
   serviceAccount: {}
     #imagePullSecret: "registry-credentials"
+  additionalVolumeMounts: []
+  additionalVolumes: []
 
 # -- values are passed as zap-flags to the containers. See https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.18.4/pkg/log/zap#Options.BindFlags for more information
 logging:
@@ -49,6 +51,8 @@ yawolController:
     repository: ghcr.io/stackitcloud/yawol/yawol-controller
     # -- Allows you to override the yawol version in this chart. Use at your own risk.
     tag: ""
+  additionalVolumeMounts: []
+  additionalVolumes: []
 
 resources:
   yawolCloudController:

--- a/example-setup/yawol-controller/provider-config.yaml
+++ b/example-setup/yawol-controller/provider-config.yaml
@@ -8,6 +8,7 @@ stringData:
     username="USERNAME"
     password="PASSWORD"
     region="RegionOne"
+    ca-file="/etc/ssl/myca.crt"
 kind: Secret
 metadata:
   name: cloud-provider-config

--- a/internal/openstack/client.go
+++ b/internal/openstack/client.go
@@ -260,7 +260,7 @@ func getProvider(
 		if err != nil {
 			return nil, nil, err
 		}
-		config := &tls.Config{}
+		config := &tls.Config{MinVersion: tls.VersionTLS12}
 		config.RootCAs = roots
 		transport = netutil.SetOldTransportDefaults(&http.Transport{TLSClientConfig: config})
 	}

--- a/internal/openstack/client.go
+++ b/internal/openstack/client.go
@@ -2,9 +2,14 @@ package openstack
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
+	"net/http"
 	"strings"
 	"time"
+
+	netutil "k8s.io/apimachinery/pkg/util/net"
+	certutil "k8s.io/client-go/util/cert"
 
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/openstack"
@@ -231,6 +236,8 @@ func getProvider(
 	projectName := strings.TrimSpace(cfg.Section("Global").Key("project-name").String())
 	authInfo.ProjectID = strings.TrimSpace(cfg.Section("Global").Key("project-id").String())
 
+	caFile := strings.TrimSpace(cfg.Section("Global").Key("ca-file").String())
+
 	// TODO: remove legacyProjectName once openstack-cloud-controller has dropped tenant-name support. Link to ccm args:
 	//nolint:lll // link
 	// https://github.com/kubernetes/cloud-provider-openstack/blob/master/docs/openstack-cloud-controller-manager/using-openstack-cloud-controller-manager.md
@@ -247,6 +254,17 @@ func getProvider(
 		authInfo.ProjectID = *overwrite.ProjectID
 	}
 
+	var transport http.RoundTripper
+	if caFile != "" {
+		roots, err := certutil.NewPool(caFile)
+		if err != nil {
+			return nil, nil, err
+		}
+		config := &tls.Config{}
+		config.RootCAs = roots
+		transport = netutil.SetOldTransportDefaults(&http.Transport{TLSClientConfig: config})
+	}
+
 	clientOpts := new(clientconfig.ClientOpts)
 	clientOpts.AuthInfo = &authInfo
 
@@ -258,6 +276,10 @@ func getProvider(
 	provider, err := openstack.NewClient(ao.IdentityEndpoint)
 	if err != nil {
 		return nil, nil, err
+	}
+
+	if transport != nil {
+		provider.HTTPClient.Transport = transport
 	}
 
 	actx, acancel := context.WithTimeout(ctx, timeout)


### PR DESCRIPTION
**How to categorize this PR?**

This PR adds the capability to use yawol against self-signed keystone Providers by reading `ca-file` from the cloud-config.
