### PR TITLE
Keep security group assignments when security group is kept

### DIFF
--- a/controllers/yawol-controller/loadbalancer/loadbalancer_controller_test.go
+++ b/controllers/yawol-controller/loadbalancer/loadbalancer_controller_test.go
@@ -813,7 +813,7 @@ var _ = Describe("loadbalancer controller", Serial, Ordered, func() {
 			})
 			It("should not delete the security group", func() {
 				portClient := mockClient.PortClientObj
-				auxilaryPortName := "auxilary-port"
+				auxiliaryPortName := "auxiliary-port"
 				securityGroupID := ""
 
 				By("checking that secgroup is set")
@@ -825,7 +825,7 @@ var _ = Describe("loadbalancer controller", Serial, Ordered, func() {
 				})
 
 				_, err := portClient.Create(ctx, ports.CreateOpts{
-					Name:           auxilaryPortName,
+					Name:           auxiliaryPortName,
 					SecurityGroups: &[]string{securityGroupID},
 				})
 				Expect(err).NotTo(HaveOccurred())
@@ -847,7 +847,7 @@ var _ = Describe("loadbalancer controller", Serial, Ordered, func() {
 				Expect(err).NotTo(HaveOccurred())
 				port := ports.Port{}
 				Expect(portList).To(ContainElement(MatchFields(IgnoreExtras, Fields{
-					"Name": Equal(auxilaryPortName),
+					"Name": Equal(auxiliaryPortName),
 				}), &port))
 				Expect(port.SecurityGroups).To(ConsistOf(securityGroupID))
 			})

--- a/controllers/yawol-controller/loadbalancer/loadbalancer_controller_test.go
+++ b/controllers/yawol-controller/loadbalancer/loadbalancer_controller_test.go
@@ -10,6 +10,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gstruct"
 
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/layer3/floatingips"
@@ -811,12 +812,23 @@ var _ = Describe("loadbalancer controller", Serial, Ordered, func() {
 				}, timeout, interval).Should(Succeed())
 			})
 			It("should not delete the security group", func() {
+				portClient := mockClient.PortClientObj
+				auxilaryPortName := "auxilary-port"
+				securityGroupID := ""
+
 				By("checking that secgroup is set")
 				hopefully(nn, func(g Gomega, act LB) error {
 					g.Expect(act.Status.SecurityGroupID).To(Not(BeNil()))
 					g.Expect(*act.Status.SecurityGroupName == nn.String())
+					securityGroupID = *act.Status.SecurityGroupID
 					return nil
 				})
+
+				_, err := portClient.Create(ctx, ports.CreateOpts{
+					Name:           auxilaryPortName,
+					SecurityGroups: &[]string{securityGroupID},
+				})
+				Expect(err).NotTo(HaveOccurred())
 
 				By("deleting the LB")
 				cleanupLB(nn, timeout)
@@ -829,6 +841,15 @@ var _ = Describe("loadbalancer controller", Serial, Ordered, func() {
 					g.Expect(err).To(Not(HaveOccurred()))
 					g.Expect(len(groups)).To(Equal(1))
 				}, timeout, interval).Should(Succeed())
+
+				By("checking the security group assignment is still there")
+				portList, err := portClient.List(ctx, ports.ListOpts{})
+				Expect(err).NotTo(HaveOccurred())
+				port := ports.Port{}
+				Expect(portList).To(ContainElement(MatchFields(IgnoreExtras, Fields{
+					"Name": Equal(auxilaryPortName),
+				}), &port))
+				Expect(port.SecurityGroups).To(ConsistOf(securityGroupID))
 			})
 			It("should not delete the fip", func() {
 				var fipIP *string


### PR DESCRIPTION
When the security group should be kept, it usually means that it is still being used. Therefore, the assignments (especially those not set up by yawol) should not be removed. The assignments to the yawol LBMs are implicitly removed when the ports are deleted, so this PR doesn't prevent the deletion of LBMs or the LB itself.