### PR TITLE
⚠️ Switch to pflag

### DIFF
--- a/charts/yawol-controller/templates/_helpers.tpl
+++ b/charts/yawol-controller/templates/_helpers.tpl
@@ -3,7 +3,7 @@ apps/v1
 {{- end -}}
 
 {{- define "logFlags" }}
-- -zap-stacktrace-level={{ .Values.logging.stacktraceLevel }}
-- -zap-log-level={{ .Values.logging.level }}
-- -zap-encoder={{ .Values.logging.encoding }}
+- --zap-stacktrace-level={{ .Values.logging.stacktraceLevel }}
+- --zap-log-level={{ .Values.logging.level }}
+- --zap-encoder={{ .Values.logging.encoding }}
 {{- end }}

--- a/charts/yawol-controller/templates/yawol-cloud-controller.yaml
+++ b/charts/yawol-controller/templates/yawol-cloud-controller.yaml
@@ -40,9 +40,9 @@ spec:
 {{- if .Values.yawolCloudController.additionalArguments }}
 {{ toYaml .Values.yawolCloudController.additionalArguments | indent 8 }}
 {{- end }}
-        - -leader-elect
+        - --leader-elect
         {{- if .Values.yawolClassName }}
-        - -classname={{ .Values.yawolClassName }}
+        - --classname={{ .Values.yawolClassName }}
         {{- end }}
         {{- include "logFlags" . | indent 8 }}
         env:

--- a/charts/yawol-controller/templates/yawol-controller.yaml
+++ b/charts/yawol-controller/templates/yawol-controller.yaml
@@ -35,16 +35,16 @@ spec:
         - containerPort: 8080
           name: metrics
         args:
-          - -leader-elect
-          - -enable-loadbalancer-controller
+          - --leader-elect
+          - --enable-loadbalancer-controller
           {{- if .Values.openstackTimeout }}
-          - -openstack-timeout={{ .Values.openstackTimeout }}
+          - --openstack-timeout={{ .Values.openstackTimeout }}
           {{- end }}
           {{- if .Values.yawolController.errorBackoffBaseDelay }}
-          - -error-backoff-base-delay={{ .Values.yawolController.errorBackoffBaseDelay }}
+          - --error-backoff-base-delay={{ .Values.yawolController.errorBackoffBaseDelay }}
           {{- end }}
           {{- if .Values.yawolController.errorBackoffMaxDelay }}
-          - -error-backoff-max-delay={{ .Values.yawolController.errorBackoffMaxDelay }}
+          - --error-backoff-max-delay={{ .Values.yawolController.errorBackoffMaxDelay }}
           {{- end }}
           {{- include "logFlags" . | indent 10 }}
         env:
@@ -73,13 +73,13 @@ spec:
           - containerPort: 8081
             name: metrics
         args:
-          - -leader-elect
-          - -enable-loadbalancerset-controller
+          - --leader-elect
+          - --enable-loadbalancerset-controller
           {{- if .Values.yawolController.errorBackoffBaseDelay }}
-          - -error-backoff-base-delay={{ .Values.yawolController.errorBackoffBaseDelay }}
+          - --error-backoff-base-delay={{ .Values.yawolController.errorBackoffBaseDelay }}
           {{- end }}
           {{- if .Values.yawolController.errorBackoffMaxDelay }}
-          - -error-backoff-max-delay={{ .Values.yawolController.errorBackoffMaxDelay }}
+          - --error-backoff-max-delay={{ .Values.yawolController.errorBackoffMaxDelay }}
           {{- end }}
           {{- include "logFlags" . | indent 10 }}
         env:
@@ -108,19 +108,19 @@ spec:
           - containerPort: 8082
             name: metrics
         args:
-          - -leader-elect
-          - -enable-loadbalancermachine-controller
+          - --leader-elect
+          - --enable-loadbalancermachine-controller
           {{- if .Values.yawolletRequeueTime }}
-          - -yawollet-requeue-time={{ .Values.yawolletRequeueTime }}
+          - --yawollet-requeue-time={{ .Values.yawolletRequeueTime }}
           {{- end }}
           {{- if .Values.openstackTimeout }}
-          - -openstack-timeout={{ .Values.openstackTimeout }}
+          - --openstack-timeout={{ .Values.openstackTimeout }}
           {{- end }}
           {{- if .Values.yawolController.errorBackoffBaseDelay }}
-          - -error-backoff-base-delay={{ .Values.yawolController.errorBackoffBaseDelay }}
+          - --error-backoff-base-delay={{ .Values.yawolController.errorBackoffBaseDelay }}
           {{- end }}
           {{- if .Values.yawolController.errorBackoffMaxDelay }}
-          - -error-backoff-max-delay={{ .Values.yawolController.errorBackoffMaxDelay }}
+          - --error-backoff-max-delay={{ .Values.yawolController.errorBackoffMaxDelay }}
           {{- end }}
           {{- include "logFlags" . | indent 10 }}
         env:


### PR DESCRIPTION
This PR refactors the command line flag handling to use `pflag` instead of `flag`.
This is a preparation for upcoming PRs, where list flags should be used, which is not supported by `flag`.

This is a breaking change because yawol components no longer accept flags with a single dash, but only with double dashes.
The helm chart is adapted accordingly, so users of the chart should not be required to adapt to this change.

Note: I decided to defer the chart version bump to a later PR so that we can release this together with the PR where we make use of `pflag`.