### PR TITLE
Fix command line flags

### DIFF
--- a/cmd/yawol-cloud-controller/main.go
+++ b/cmd/yawol-cloud-controller/main.go
@@ -9,19 +9,17 @@ import (
 	"time"
 
 	"github.com/spf13/pflag"
-	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
-	// to ensure that exec-entrypoint and run can make use of them.
-	_ "k8s.io/client-go/plugin/pkg/client/auth"
-	"k8s.io/client-go/rest"
-	"k8s.io/client-go/tools/clientcmd"
-	"k8s.io/utils/ptr"
-	"sigs.k8s.io/controller-runtime/pkg/cache"
-
 	"go.uber.org/zap/zapcore"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	_ "k8s.io/client-go/plugin/pkg/client/auth" // Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/server"
@@ -91,6 +89,11 @@ func main() {
 	var leasesRetryPeriod time.Duration
 
 	fs := pflag.NewFlagSet("yawol-cloud-controller", pflag.ExitOnError)
+
+	// register --kubeconfig flag in FlagSet
+	configFlagSet := flag.NewFlagSet("config", flag.ContinueOnError)
+	config.RegisterFlags(configFlagSet)
+	fs.AddGoFlagSet(configFlagSet)
 
 	fs.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
 	fs.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")

--- a/cmd/yawol-controller/main.go
+++ b/cmd/yawol-controller/main.go
@@ -7,16 +7,6 @@ import (
 	"os"
 	"time"
 
-	"github.com/stackitcloud/yawol/controllers/yawol-controller/loadbalancer"
-	"github.com/stackitcloud/yawol/controllers/yawol-controller/loadbalancermachine"
-	"github.com/stackitcloud/yawol/controllers/yawol-controller/loadbalancerset"
-
-	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
-	// to ensure that exec-entrypoint and run can make use of them.
-	_ "k8s.io/client-go/plugin/pkg/client/auth"
-	"sigs.k8s.io/controller-runtime/pkg/cache"
-	"sigs.k8s.io/controller-runtime/pkg/manager"
-
 	"github.com/spf13/pflag"
 	"go.uber.org/zap/zapcore"
 	"golang.org/x/time/rate"
@@ -24,12 +14,19 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/discovery"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	_ "k8s.io/client-go/plugin/pkg/client/auth" // Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	"k8s.io/client-go/util/workqueue"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
 	yawolv1beta1 "github.com/stackitcloud/yawol/api/v1beta1"
+	"github.com/stackitcloud/yawol/controllers/yawol-controller/loadbalancer"
+	"github.com/stackitcloud/yawol/controllers/yawol-controller/loadbalancermachine"
+	"github.com/stackitcloud/yawol/controllers/yawol-controller/loadbalancerset"
 	helpermetrics "github.com/stackitcloud/yawol/internal/metrics"
 	//+kubebuilder:scaffold:imports
 )
@@ -82,6 +79,11 @@ func main() {
 	var leasesRetryPeriod time.Duration
 
 	fs := pflag.NewFlagSet("yawol-controller", pflag.ExitOnError)
+
+	// register --kubeconfig flag in FlagSet
+	configFlagSet := flag.NewFlagSet("config", flag.ContinueOnError)
+	config.RegisterFlags(configFlagSet)
+	fs.AddGoFlagSet(configFlagSet)
 
 	fs.StringVar(&metricsAddrLb, "metrics-addr-lb", ":8080", "The address the metric endpoint binds to.")
 	fs.StringVar(&metricsAddrLbs, "metrics-addr-lbm", ":8081", "The address the metric endpoint binds to.")

--- a/internal/helper/loadbalancermachine.go
+++ b/internal/helper/loadbalancermachine.go
@@ -289,15 +289,15 @@ func GenerateUserData(
 	}
 
 	var yawolletArgs string
-	yawolletArgs = yawolletArgs + "-namespace=" + loadbalancerMachine.Namespace + " "
-	yawolletArgs = yawolletArgs + "-loadbalancer-name=" + loadbalancer.Name + " "
-	yawolletArgs = yawolletArgs + "-loadbalancer-machine-name=" + loadbalancerMachine.Name + " "
-	yawolletArgs = yawolletArgs + "-listen-address=" + vip + " "
-	yawolletArgs = yawolletArgs + "-health-probe-bind-address=" + probeAddress + " "
-	yawolletArgs = yawolletArgs + "-kubeconfig /etc/yawol/kubeconfig" + " "
+	yawolletArgs = yawolletArgs + "--namespace=" + loadbalancerMachine.Namespace + " "
+	yawolletArgs = yawolletArgs + "--loadbalancer-name=" + loadbalancer.Name + " "
+	yawolletArgs = yawolletArgs + "--loadbalancer-machine-name=" + loadbalancerMachine.Name + " "
+	yawolletArgs = yawolletArgs + "--listen-address=" + vip + " "
+	yawolletArgs = yawolletArgs + "--health-probe-bind-address=" + probeAddress + " "
+	yawolletArgs = yawolletArgs + "--kubeconfig /etc/yawol/kubeconfig" + " "
 
 	if yawolletRequeueTime > 0 {
-		yawolletArgs = yawolletArgs + "-requeue-time=" + strconv.Itoa(yawolletRequeueTime) + " "
+		yawolletArgs = yawolletArgs + "--requeue-time=" + strconv.Itoa(yawolletRequeueTime) + " "
 	}
 
 	return `


### PR DESCRIPTION
This is a follow-up to https://github.com/stackitcloud/yawol/pull/407, where I missed two aspects:

The LBM user-data must be adapted to pass double-dash flags to yawollet.
Note that double-dash flags also work for `flag`. Hence, rolling out this version of yawol-controller (specifying double-dashes in user-data) but keeping the old yawollet image (using `pflag`) will still work but not vice-versa.

Also, controller-runtime registers the `--kubeconfig` flag in the default `flag.CommandLine`. Hence, we must bring it back by explicitly registering it in the `pflag.FlagSet`.