### PR TITLE
Clean up local yawollet image build

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -105,8 +105,8 @@ validate-yawollet-image:
 build-yawollet-image:
     FROM +packer
 
-    ARG USEROS
-    ARG USERARCH
+    ARG TARGETOS
+    ARG TARGETARCH
 
     ARG MACHINE_FLAVOR=c1.2
     ARG VOLUME_TYPE=storage_premium_perf6
@@ -127,7 +127,7 @@ build-yawollet-image:
 
     COPY +get-envoy/envoy out/envoy/envoy
     COPY +get-envoy/envoylibs out/envoy/lib
-    COPY (+build/controller --CONTROLLER=yawollet --GOOS=$USEROS --GOARCH=$USERARCH) out/yawollet
+    COPY (+build/controller --CONTROLLER=yawollet --GOOS=$TARGETOS --GOARCH=$TARGETARCH) out/yawollet
     COPY +set-version/VERSION .
 
     COPY image image

--- a/Earthfile
+++ b/Earthfile
@@ -337,6 +337,10 @@ golangci-lint:
 
 packer:
     FROM hashicorp/packer:$PACKER_VERSION
+
+    # set this env var to get higher GitHub API requests
+    ARG PACKER_GITHUB_API_TOKEN
+
     RUN packer plugins install github.com/hashicorp/openstack
     RUN apk add ansible
     RUN apk add openssh-client

--- a/README.md
+++ b/README.md
@@ -87,9 +87,8 @@ earthly +destroy-packer-environment \
 Before running our `Earthly` targets, set the needed environment variables:
 
 ```shell
-export OS_NETWORK_ID=<from your openstack environment>
-export OS_FLOATING_NETWORK_ID=<from your openstack environment>
-export OS_SECURITY_GROUP_ID=<from your openstack environment>
+# set OS_NETWORK_ID, OS_FLOATING_NETWORK_ID, OS_SECURITY_GROUP_ID from terraform state
+source <(jq -r '.outputs | del(.OS_SOURCE_IMAGE) | keys[] as $k | "export \($k)=\(.[$k].value)"' hack/packer-infrastructure/terraform.tfstate)
 export OS_SOURCE_IMAGE=<from your openstack environment>
 export IMAGE_VISIBILITY=<private or public> 
 ```

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ earthly +validate-yawollet-image
 ```
 
 ```shell
-earthly +build-yawollet-image \
+earthly --platform=linux/amd64 +build-yawollet-image \
    --OS_NETWORK_ID="$OS_NETWORK_ID" \
    --OS_FLOATING_NETWORK_ID="$OS_FLOATING_NETWORK_ID" \
    --OS_SECURITY_GROUP_ID="$OS_SECURITY_GROUP_ID" \

--- a/hack/packer-infrastructure/main.tf
+++ b/hack/packer-infrastructure/main.tf
@@ -6,10 +6,6 @@ terraform {
       source  = "terraform-provider-openstack/openstack"
       version = ">= 1.47"
     }
-    template = {
-      source  = "hashicorp/template"
-      version = "2.2.0"
-    }
   }
 }
 

--- a/hack/packer-infrastructure/main.tf
+++ b/hack/packer-infrastructure/main.tf
@@ -13,6 +13,4 @@ terraform {
   }
 }
 
-provider "openstack" {
-  use_octavia = false
-}
+provider "openstack" {}


### PR DESCRIPTION
This PR improves and fixes several things for locally building yawollet images.
Most notably, this PR fixes builds from other platforms than `linux/amd64` to result in the right target platform.