### PR TITLE
⚠️  Ignore inline comment when parsing cloud provider config

### DIFF
--- a/internal/openstack/client.go
+++ b/internal/openstack/client.go
@@ -218,7 +218,10 @@ func getProvider(
 	overwrite OSClientOverwrite,
 	timeout time.Duration,
 ) (*gophercloud.ProviderClient, *gophercloud.EndpointOpts, error) {
-	cfg, err := ini.Load(iniData)
+	cfg, err := ini.LoadSources(
+		ini.LoadOptions{IgnoreInlineComment: true},
+		iniData,
+	)
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
Cloud provider passwords can contain # or ; characters. These caused the parser to drop the password part after the "comment" character and thereby break authentication.