### PR TITLE
Add proxy support for loki log upload

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,6 +279,8 @@ metadata:
     yawol.stackit.cloud/logForward: "true"
     # Defines loki URL for the log forwarding.
     yawol.stackit.cloud/logForwardLokiURL: "http://example.com:3100/loki/api/v1/push"
+    # Defines proxy URL for the log forwarding.
+    yawol.stackit.cloud/logForwardProxyURL: "http://proxy.example.com:8000"
     # Defines labels that are added when forwarding logs
     # The prefix "logging.yawol.stackit.cloud/" will be trimmed
     # and only "foo": "bar" will be added as a label

--- a/api/v1beta1/loadbalancer_types.go
+++ b/api/v1beta1/loadbalancer_types.go
@@ -55,6 +55,8 @@ const (
 	ServiceLogForward = "yawol.stackit.cloud/logForward"
 	// ServiceLogForwardLokiURL set loki url into LoadBalancer
 	ServiceLogForwardLokiURL = "yawol.stackit.cloud/logForwardLokiURL"
+	// ServiceLogForwardProxyURL set proxy url to connect to loki
+	ServiceLogForwardProxyURL = "yawol.stackit.cloud/logForwardProxyURL"
 	// ServiceServerGroupPolicy set openstack server group policy for a LoadBalancer
 	ServiceServerGroupPolicy = "yawol.stackit.cloud/serverGroupPolicy"
 	// ServiceAdditionalNetworks adds additional openstack networks for the loadbalancer (comma separated list)
@@ -179,6 +181,9 @@ type LoadBalancerLogForward struct {
 	// LokiUrl defines the loki push url (Example: http://example.com:3100/loki/api/v1/push).
 	// +optional
 	LokiURL string `json:"lokiUrl"`
+	// ProxyUrl defines the http proxy url to use for connection to loki
+	// +optional
+	ProxyURL string `json:"proxyUrl"`
 	// Labels define extra labels for loki.
 	// +optional
 	Labels map[string]string `json:"labels"`

--- a/charts/yawol-controller/crds/yawol.stackit.cloud_loadbalancers.yaml
+++ b/charts/yawol-controller/crds/yawol.stackit.cloud_loadbalancers.yaml
@@ -251,6 +251,10 @@ spec:
                         description: 'LokiUrl defines the loki push url (Example:
                           http://example.com:3100/loki/api/v1/push).'
                         type: string
+                      proxyUrl:
+                        description: ProxyUrl defines the http proxy url to use for
+                          connection to loki
+                        type: string
                     type: object
                   serverGroupPolicy:
                     description: |-

--- a/internal/helper/loadbalancermachine.go
+++ b/internal/helper/loadbalancermachine.go
@@ -487,11 +487,6 @@ func generatePromtailConfig(
 		return "", err
 	}
 
-	proxy := ""
-	if logForward.ProxyURL != "" {
-		proxy = "    proxy_url: '" + logForward.ProxyURL + "'"
-	}
-
 	return `server:
   disable: true
 
@@ -500,7 +495,7 @@ positions:
 
 clients:
   - url: '` + logForward.LokiURL + `'
-` + proxy + `
+    proxy_url: '` + logForward.ProxyURL + `'
 
 scrape_configs:
   - job_name: messages

--- a/internal/helper/loadbalancermachine.go
+++ b/internal/helper/loadbalancermachine.go
@@ -487,6 +487,11 @@ func generatePromtailConfig(
 		return "", err
 	}
 
+	proxy := ""
+	if logForward.ProxyURL != "" {
+		proxy = "\n    proxy_url: '" + logForward.ProxyURL + "'"
+	}
+
 	return `server:
   disable: true
 
@@ -494,7 +499,7 @@ positions:
   filename: /tmp/positions.yaml
 
 clients:
-  - url: '` + logForward.LokiURL + `'
+  - url: '` + logForward.LokiURL + "'" + proxy + `
 
 scrape_configs:
   - job_name: messages

--- a/internal/helper/loadbalancermachine.go
+++ b/internal/helper/loadbalancermachine.go
@@ -489,7 +489,7 @@ func generatePromtailConfig(
 
 	proxy := ""
 	if logForward.ProxyURL != "" {
-		proxy = "\n    proxy_url: '" + logForward.ProxyURL + "'"
+		proxy = "    proxy_url: '" + logForward.ProxyURL + "'"
 	}
 
 	return `server:
@@ -499,7 +499,8 @@ positions:
   filename: /tmp/positions.yaml
 
 clients:
-  - url: '` + logForward.LokiURL + "'" + proxy + `
+  - url: '` + logForward.LokiURL + `'
+` + proxy + `
 
 scrape_configs:
   - job_name: messages

--- a/internal/helper/loadbalancermachine_test.go
+++ b/internal/helper/loadbalancermachine_test.go
@@ -34,7 +34,7 @@ positions:
 
 clients:
   - url: 'localhost'
-
+    proxy_url: ''
 
 scrape_configs:
   - job_name: messages

--- a/internal/helper/loadbalancermachine_test.go
+++ b/internal/helper/loadbalancermachine_test.go
@@ -35,6 +35,7 @@ positions:
 clients:
   - url: 'localhost'
 
+
 scrape_configs:
   - job_name: messages
     static_configs:

--- a/internal/helper/loadbalancermachine_test.go
+++ b/internal/helper/loadbalancermachine_test.go
@@ -52,6 +52,41 @@ scrape_configs:
 				Expect(config).To(Equal(expected))
 			})
 		})
+		When("proxy url is set", func() {
+			It("should render it in the promtail config", func() {
+				logForward := yawolv1beta1.LoadBalancerLogForward{
+					LokiURL:  "localhost",
+					ProxyURL: "proxy-url",
+				}
+
+				config, err := generatePromtailConfig("some-lb", "some-lbm", logForward)
+				Expect(err).ToNot(HaveOccurred())
+
+				expected := `server:
+  disable: true
+
+positions:
+  filename: /tmp/positions.yaml
+
+clients:
+  - url: 'localhost'
+    proxy_url: 'proxy-url'
+
+scrape_configs:
+  - job_name: messages
+    static_configs:
+      - targets:
+          - localhost
+        labels:
+          __path__: /var/log/messages
+          application: messages
+          job: yawol-logs
+          lb: some-lb
+          lbm: some-lbm
+          `
+				Expect(config).To(Equal(expected))
+			})
+		})
 	})
 })
 

--- a/internal/helper/service.go
+++ b/internal/helper/service.go
@@ -75,6 +75,9 @@ func GetOptions(svc *coreV1.Service, recorder record.EventRecorder) yawolv1beta1
 		if svc.Annotations[yawolv1beta1.ServiceLogForwardLokiURL] != "" {
 			options.LogForward.LokiURL = svc.Annotations[yawolv1beta1.ServiceLogForwardLokiURL]
 		}
+		if svc.Annotations[yawolv1beta1.ServiceLogForwardProxyURL] != "" {
+			options.LogForward.ProxyURL = svc.Annotations[yawolv1beta1.ServiceLogForwardProxyURL]
+		}
 
 		labels := map[string]string{}
 		for annotation := range svc.Annotations {


### PR DESCRIPTION
The annotation `yawol.stackit.cloud/logForwardProxyURL` now allows configuring a proxy url to use when sending logs to loki. This is required to support log submission for environments without direct internet access.