### PR TITLE
hack/test: make tcp-timeout test portable

### DIFF
--- a/hack/tests/README.md
+++ b/hack/tests/README.md
@@ -49,11 +49,17 @@ echo "test"  | nc -u $(kubectl get services udp-timeout --output jsonpath='{.sta
 
 ## tcp-timeout
 
-This command should be closed in 10 sec
+This command should be closed with no output in approximately 10 sec
+
+Bash:
 ```
-time nc $(kubectl get services tcp-timeout --output jsonpath='{.status.loadBalancer.ingress[0].ip}') 80
+time nc $(kubectl get services tcp-timeout --output jsonpath='{.status.loadBalancer.ingress[0].ip}') 80 < <( sleep 11; echo "test" )
 ```
 
+Zsh:
+```
+{ sleep 11; echo "test" } | time nc $(kubectl get services tcp-timeout --output jsonpath='{.status.loadBalancer.ingress[0].ip}') 80
+```
 
 ## cleanup 
 


### PR DESCRIPTION
At least on Linux nc does not automatically close the sending side of the connection when the receiving side is closed by yawol. Extend the test to send a message after the idle timeout to trigger a forceful close of the sending side of the connection.