### PR TITLE
ci(tests): migrate to gha-runner-scale-set

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   test:
-    runs-on: self-hosted
+    runs-on: gha-runner-scale-set
     permissions:
       contents: read
     env:


### PR DESCRIPTION
Once https://github.com/stackitcloud/ske-stages/pull/6222 is merged. We need to change the `runs-on`