### PR TITLE
Switch test pipeline to public runners

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   test:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     permissions:
       contents: read
     env:
@@ -25,18 +25,6 @@ jobs:
         git checkout -b "$branch" || true
     - name: Install earthly
       run: "sudo /bin/sh -c 'curl -o /usr/local/bin/earthly -L https://github.com/earthly/earthly/releases/download/v0.8.16/earthly-linux-amd64 && chmod +x /usr/local/bin/earthly'"
-    - name: Configure pull-through-cache
-      run: |
-        mkdir ~/.earthly
-        cat <<EOF > ~/.earthly/config.yml
-        global:
-          buildkit_additional_config: |
-            [registry."docker.io"]
-              mirrors = ["yawol-registry-docker-registry.yawol-registry.svc:5000"]
-            [registry."yawol-registry-docker-registry.yawol-registry.svc:5000"]
-              http = true
-              insecure = true
-        EOF
     - name: Earthly version
       run: earthly --version
     - name: Run Tests


### PR DESCRIPTION
Simplify the CI setup. Also drop the yawol registry cache configuration which didn't work anyways.